### PR TITLE
feat(todo-app): add todo app template with Docker local dev support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The CLI reads `rayfin-template.yml` at the repo root and presents an interactive
 |----------|-------------|:----:|:----:|-------|
 | **[Events App](./templates/events-app)** | Events management app with scheduling, listings, and Fabric authentication | ✅ | ✅ | React, Vite, Tailwind |
 | **[Field Engineer](./templates/field-engineer)** | Field engineer task management app with Fabric authentication, data tracking, and React + Vite | ✅ | ✅ | React, Vite, Tailwind |
+| **[Todo App](./templates/todo-app)** | Full-stack todo app with categories, auth, and Docker local development | ✅ | ✅ | React, Vite, Tailwind |
 
 > **Adding a template?** See the [Contributing Guide](CONTRIBUTING.md).
 

--- a/rayfin-template.yml
+++ b/rayfin-template.yml
@@ -10,3 +10,6 @@ entries:
   - path: templates/field-engineer
     name: Field Engineer
     description: Field engineer task management app with Fabric authentication, data tracking, and React + Vite
+  - path: templates/todo-app
+    name: Todo App
+    description: Full-stack todo app with categories, auth, and Docker local development

--- a/templates/todo-app/.agents/skills/rayfin/SKILL.md
+++ b/templates/todo-app/.agents/skills/rayfin/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: rayfin
+description: "Use when doing ANY task involving Rayfin — scaffolding, data models, decorators, auth, deployment, CLI commands, or client setup. Triggers: rayfin, rayfin init, rayfin up, rayfin login, RayfinClient, @entity, @role, @anonymous, @authenticated, @text, @uuid, @int, @decimal, @boolean, @date, @email, @set, @one, @many, DAB, Data API Builder, rayfin.yml, publishableKey, signUp, signIn, signOut, sendMagicLink, handleMagicLinkCallback, ensureSignedInWithFabric, Fabric SSO, Entra ID, rayfin up db apply, rayfin up staticapp deploy, schema.ts, OpaqueSession, onSessionChange, GraphQL select, GraphQL create, GraphQL update, GraphQL delete, findById, executePaginated, RLS policy, row-level security, claims.sub, claims.email, TC39 decorators, config generation, dialect, mssql, postgresql"
+metadata:
+  author: microsoft
+  version: 0.3.0
+rayfin-managed: true
+---
+# Rayfin
+
+## Rayfin Docs
+
+Rayfin's documentation is available via MCP tools and the `rayfin docs` CLI.
+Use these for code examples, API details, and troubleshooting — not this skill.
+Docs are version-locked to the Rayfin packages installed in the user's project.
+Run MCP and CLI lookups from the project root so local `node_modules` wins whether the CLI/MCP package is installed locally, globally, or through `npx`.
+
+**MCP tools** (if the `rayfin` MCP server is connected):
+
+- `search_docs(query: '<topic>', module: 'guide')` — builder guides and tutorials
+- `search_docs(query: '<topic>', module: 'ts-sdk')` — TypeScript SDK API reference
+- `get_doc(symbol: '<decorator or class>')` — resolve a symbol to its docs
+- `discover_packages(query: '<topic>')` — find missing or too-old Rayfin packages when installed docs do not cover the task
+
+**CLI fallback** (when MCP is unavailable):
+
+- `rayfin docs search '<topic>' --module guide` — builder guides and tutorials
+- `rayfin docs search '<topic>' --module ts-sdk` — TypeScript SDK API reference
+- `rayfin docs get --symbol '<decorator or class>'` — resolve a symbol to its docs
+- `rayfin docs discover '<topic>'` — find a Rayfin package when installed docs do not cover the task
+
+If `rayfin` is not on `PATH`, use `npx -y @microsoft/rayfin-cli docs ...` from the project root.
+
+Key doc topics:
+
+- Known limitations — FK naming, constraint limits, relationship rules
+- Data permissions — `@role` decorator, policy DSL, field visibility
+- GraphQL data access — RayfinClient setup, query chain, mutations
+- Auth overview — auth methods, session handling
+- Fabric deployment — workspace and static app deployment workflow
+
+**Before creating entities or writing queries**, check known limitations:
+
+```text
+search_docs(query: 'known limitations', module: 'guide')
+# or: npx -y @microsoft/rayfin-cli docs search 'known limitations' --module guide
+```
+
+## Rules
+
+### Platform
+
+- Rayfin uses TC39 Stage 3 decorators — never enable `experimentalDecorators` or `emitDecoratorMetadata`.
+- Include `ESNext.Decorators` in the tsconfig `lib` array.
+- Two deployment targets: Rayfin Local (Docker, MSSQL or PostgreSQL) and Fabric Apps (managed, MSSQL only).
+- Prefer `npm create @microsoft/rayfin@latest` for new projects — it generates correct tsconfig and schema boilerplate.
+
+### Security
+
+- Every entity must have an explicit permission decorator (`@role`, `@anonymous`, `@authenticated`) — entities without one are inaccessible.
+- Add `policy: (claims, item) => claims.sub.eq(item.user_id)` for row-level filtering on user-scoped data.
+- Use `exclude` in role options to hide sensitive fields (e.g., `exclude: ['secret']`).
+- Publishable keys (`pk-*`) are safe for client-side code — never expose service secrets or connection strings.
+- Keep `allowedRedirectUris` in `rayfin.yml` tightly scoped to your app's origin.
+- Email/password auth is local development only — deployed Fabric apps support Fabric SSO (Entra ID) exclusively.
+- Fabric SSO only works inside the Fabric Portal — do not attempt it in local development.
+
+### Data Modeling
+
+- Define entities with `@entity()` in `rayfin/data/` and register them in `rayfin/data/schema.ts` as `type AppSchema = { Name: Name }`.
+- Every field needs exactly one decorator: `@uuid`, `@text`, `@int`, `@decimal`, `@boolean`, `@date`, `@email`, `@set`.
+- Fields are required by default — use `{ optional: true }` and `?` together for nullable fields.
+- `@text()` length option is `max` (not `maxLength`) — e.g., `@text({ max: 200 })`.
+- Use `@one(() => Target)` with lazy arrow functions for relationships — Rayfin auto-generates FK columns named `{property}_id`.
+- Use `import` (not `import type`) for entity classes referenced in `@one()`/`@many()` arrow functions — decorators need the runtime class value.
+- FK columns referencing another entity (`{property}_id`) must use `@uuid()` to match the PK type. Auth-based fields like `user_id` from `claims.sub` use `@text()`.
+- Many-to-many requires an explicit join entity with two `@one()` fields.
+- Use `@many(() => Target)` for the inverse side of relationships.
+
+### Querying
+
+- Query chain: `.select()` → `.where()` → `.orderBy()` → `.execute()`.
+- Single record by ID: `client.data.Entity.findById('uuid-here')` — not `findByPk`.
+- Filter by FK columns using `{property}_id` (e.g., `customer_id`), not dot-path (e.g., `customer.id`).
+- Dot-paths are for `.select()` only (e.g., `customer.companyName`).
+- Use `.first(n).executePaginated()` for cursor-based pagination.
+- Sort directions must be lowercase: `'asc'` or `'desc'`.
+
+### Schema
+
+- **For Fabric:** `rayfin up` is the canonical command for "deploy this change," "apply this schema change," or "push my entity update" — it deploys the app and applies pending schema migrations in a single step. Recommend it on every deploy, including incremental schema changes after the initial deploy.
+- `rayfin up db apply` is a narrow advanced subcommand that applies schema-only without touching the static build — only recommend it when the user explicitly asks to skip the static deploy step.
+- `--force` permits destructive changes (drop table, drop column, alter type) — never use without review.
+- `--gen-config-only` generates the underlying API config without applying — use to inspect before applying.
+
+### Deployment
+
+- When the user asks to "build and deploy," "make it live," or "deploy this change" (including schema-only changes like adding a column), execute the full workflow — do not present steps as instructions for the user to run manually.
+- Workflow: `rayfin login` → `rayfin up` → `rayfin up status`. `rayfin up` builds the static app, deploys it, and applies any pending schema migrations.
+- `rayfin up status` checks endpoint health — run after deployment to verify.
+- Deployment metadata is written to `rayfin/.deployments.json` (per-workspace record: `fabricItemId`, `hostingUrl`, `publishableKey`, etc.). The deploy also appends the live hosting URL to `allowedRedirectUris` in `rayfin.yml`.
+
+## Anti-Patterns
+
+- Never use raw `fetch()` or hand-built GraphQL for data operations — always use `client.data.<Entity>` (provides type-safe queries and automatic auth).
+- Never omit permission decorators on entities — always add an explicit `@permissions(...)`. Forgetting silently applies `authenticated: *` (full CRUD for any signed-in user), which is usually too permissive for production data.
+- Never use `@text()` without `max` on MSSQL — always set `@text({ max: N })` (e.g. `max: 200` for typical strings). `NVARCHAR(MAX)` breaks GraphQL schema generation and cannot be uniquely indexed.
+- Never use `@text()` for FK columns that reference another entity's `@uuid()` PK — use `@uuid()` to match types. (`user_id` from `claims.sub` is `@text()`, not a FK.)
+- Never skip `search_docs('known limitations')` before implementing entities — always run it first to surface platform constraints (text length caps, supported scalar types, MSSQL-specific gotchas) that affect entity design.
+
+## CLI Quick Reference
+
+```bash
+# Scaffold
+npm create @microsoft/rayfin@latest <name>   # Create from template
+npx rayfin init [directory]                   # Interactive setup
+
+# Deploy to Fabric (default workflow)
+npx rayfin login                              # Sign in with Entra ID
+npx rayfin up                                 # Deploy app + apply schema (canonical)
+npx rayfin up status                          # Check deployment health
+npx rayfin up db apply                        # Schema-only, skip static deploy (advanced)
+npx rayfin up staticapp deploy                # Redeploy static content
+```

--- a/templates/todo-app/.gitignore
+++ b/templates/todo-app/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.env
+.env.local
+.env.*.local
+rayfin/.temp/
+rayfin/.env
+rayfin/.deployments.json
+.DS_Store

--- a/templates/todo-app/.mcp.json
+++ b/templates/todo-app/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "rayfin": {
+      "args": [
+        "-y",
+        "@microsoft/rayfin-mcp",
+        "start"
+      ],
+      "command": "npx",
+      "type": "stdio"
+    }
+  }
+}

--- a/templates/todo-app/AGENTS.md
+++ b/templates/todo-app/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+This project ships Rayfin agent context.
+Load `.agents/skills/rayfin/SKILL.md` and the `rayfin` MCP server in `.mcp.json` before writing Rayfin code.
+
+Rayfin docs are version-locked to the packages installed in this project.
+Prefer the MCP tools `search_docs`, `get_doc`, `list_docs`, and `discover_packages` for examples, API details, and troubleshooting.
+If MCP is unavailable, run `rayfin docs ...` from the project root so the CLI reads this project's `node_modules`.
+If `rayfin` is not on `PATH`, use `npx -y @microsoft/rayfin-cli docs ...` from the project root.
+
+Use `discover_packages` or `rayfin docs discover <topic>` when installed docs do not cover the task.
+
+## Docker local development
+
+This template includes Docker local development support behind the `docker-local-dev` feature flag.
+
+Key scripts:
+- `npm run dev:local` — starts the full Docker-based backend (checks GHCR auth first)
+- `npm run dev:local:db` — applies database schema to local Docker environment
+- `npm run dev:local:stop` / `dev:local:purge` — stop or reset the local environment
+
+The GHCR check script (`scripts/check-docker-ghcr.mjs`) validates Docker is running and
+the user is authenticated to `ghcr.io` before allowing `dev:local` to proceed.

--- a/templates/todo-app/README.md
+++ b/templates/todo-app/README.md
@@ -1,0 +1,117 @@
+# Todo App
+
+Full-stack todo app with categories, auth, and Docker local development built on Rayfin.
+
+## Getting started
+
+```bash
+# Install dependencies
+npm install
+
+# Deploy app to Fabric and start the local dev server
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) to view the app.
+
+### Service modes
+
+The app supports two service modes:
+
+| Mode | Command | Description |
+|------|---------|-------------|
+| **Rayfin** | `npm run dev:rayfin` | Connects to the Rayfin backend API (default) |
+| **Mock** | `npm run dev:mock` | Uses localStorage — no backend required |
+
+Toggle between modes with `npm run toggle-mode [mock\|rayfin]`.
+
+### Docker local development (preview)
+
+Run the full Rayfin backend locally via Docker containers:
+
+```bash
+# One-time setup: authenticate to GitHub Container Registry
+gh auth login
+gh auth refresh --scopes read:packages
+gh auth token | docker login ghcr.io -u $(gh api user -q .login) --password-stdin
+
+# Start the Docker local dev environment
+npm run dev:local
+```
+
+> **Note:** `dev:local` automatically checks that Docker is running and that you
+> are authenticated to `ghcr.io`. See [GHCR authentication](#ghcr-authentication)
+> below for alternative setup methods.
+
+## Project structure
+
+```text
+├── rayfin/
+│   ├── rayfin.yml          # Fabric service configuration
+│   ├── data/
+│   │   ├── Todo.ts         # Todo entity with RLS policy
+│   │   ├── Category.ts     # Category entity with relationships
+│   │   └── schema.ts       # Data schema type definition
+│   └── storage/
+│       ├── ProfileImage.ts # Blob storage entity
+│       └── schema.ts       # Storage schema type definition
+├── src/
+│   ├── main.tsx            # Entry point + Rayfin client bootstrap
+│   ├── App.tsx             # Routes and auth gate
+│   ├── models/             # TypeScript type definitions
+│   ├── components/         # Shared UI components (auth, todos, categories)
+│   ├── hooks/              # React hooks (useAuth, useTodos, useCategories, …)
+│   ├── pages/              # Page components (Dashboard, AuthCallback, …)
+│   ├── services/
+│   │   ├── interfaces/     # Service contracts (ITodoService, IAuthService, …)
+│   │   ├── mock/           # localStorage-backed implementations
+│   │   └── rayfin/         # Rayfin API-backed implementations
+│   └── utils/              # Environment helpers
+├── scripts/
+│   ├── check-docker-ghcr.mjs    # GHCR auth pre-flight check
+│   ├── toggle-service-mode.js   # Switch between mock and rayfin modes
+│   └── run-rayfin-db.js         # Apply database schema changes
+└── package.json
+```
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Deploy app to Fabric and start local dev server |
+| `npm run dev:mock` | Start in mock mode (localStorage, no backend) |
+| `npm run dev:rayfin` | Apply DB schema and start in Rayfin mode |
+| `npm run dev:local` | Start Docker local dev environment (preview) |
+| `npm run dev:local:db` | Apply database schema to local Docker environment |
+| `npm run dev:local:status` | Show status of Docker local dev containers |
+| `npm run dev:local:stop` | Stop Docker local dev containers |
+| `npm run dev:local:purge` | Stop, remove containers, and delete volumes |
+| `npm run check:ghcr` | Check Docker and GHCR authentication |
+| `npm run toggle-mode` | Toggle between mock and rayfin service modes |
+| `npm run build` | Production build |
+| `npm run build:fabric` | Build for Fabric deployment |
+| `npm run lint` | Lint with ESLint |
+| `npm run test` | Run unit tests with Vitest |
+| `npm run rayfin:up` | Deploy app to Fabric (no local dev server) |
+
+## GHCR authentication
+
+The Docker local dev environment pulls the Rayfin host container from
+`ghcr.io`. You need `read:packages` access to the GitHub organization.
+
+**Option 1 — GitHub CLI (recommended):**
+
+```bash
+gh auth login
+gh auth refresh --scopes read:packages
+gh auth token | docker login ghcr.io -u $(gh api user -q .login) --password-stdin
+```
+
+**Option 2 — Personal Access Token:**
+
+Create a PAT with `read:packages` scope at <https://github.com/settings/tokens>,
+then:
+
+```bash
+echo <YOUR_PAT> | docker login ghcr.io -u <GITHUB_USERNAME> --password-stdin
+```

--- a/templates/todo-app/eslint.config.js
+++ b/templates/todo-app/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+);

--- a/templates/todo-app/index.html
+++ b/templates/todo-app/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo App</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/templates/todo-app/manifest.json
+++ b/templates/todo-app/manifest.json
@@ -1,0 +1,18 @@
+{
+  "templateId": "todo-app",
+  "icon": "todo-app",
+  "services": {
+    "auth": true,
+    "data": true,
+    "storage": false,
+    "staticHosting": true
+  },
+  "hasDabSchema": true,
+  "tokens": [
+    "__RAYFIN_API_URL__",
+    "__RAYFIN_PK__",
+    "__FABRIC_ITEM_ID__",
+    "__FABRIC_WORKSPACE_ID__",
+    "__FABRIC_PORTAL_URL__"
+  ]
+}

--- a/templates/todo-app/package.json
+++ b/templates/todo-app/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "todo-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "template": {
+    "name": "todo-app",
+    "displayName": "Todo App",
+    "description": "Full-stack todo app with categories, auth, and Docker local development"
+  },
+  "scripts": {
+    "predev": "rayfin env --framework vite",
+    "prebuild": "rayfin env --framework vite",
+    "dev": "rayfin up --exclude-services staticHosting && vite",
+    "dev:mock": "node scripts/toggle-service-mode.js mock && npm run dev",
+    "dev:rayfin": "node scripts/run-rayfin-db.js && node scripts/toggle-service-mode.js rayfin && npm run dev",
+    "dev:local": "npm run check:ghcr && cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev",
+    "dev:local:db": "cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev db apply",
+    "dev:local:status": "cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev status",
+    "dev:local:stop": "cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev --stop",
+    "dev:local:purge": "cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev --purge",
+    "check:ghcr": "node scripts/check-docker-ghcr.mjs",
+    "toggle-mode": "node scripts/toggle-service-mode.js",
+    "build": "tsc -b && vite build",
+    "build:fabric": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "rayfin:up": "rayfin up"
+  },
+  "dependencies": {
+    "@microsoft/rayfin-auth-provider-fabric": "^1.32.0",
+    "@microsoft/rayfin-client": "^1.32.0",
+    "@microsoft/rayfin-core": "^1.32.0",
+    "@microsoft/rayfin-data": "^1.32.0",
+    "@microsoft/rayfin-storage": "^1.32.0",
+    "@tailwindcss/vite": "^4.1.11",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.21.0",
+    "@microsoft/rayfin-cli": "^1.23.0",
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "cross-env": "^7.0.3",
+    "eslint": "^9.28.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.19",
+    "globals": "^16.0.0",
+    "jsdom": "^24.1.0",
+    "tailwindcss": "^4.1.11",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.38.0",
+    "vite": "^7.3.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/templates/todo-app/rayfin-template.yml
+++ b/templates/todo-app/rayfin-template.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+metadata:
+  name: todo-app
+  displayName: Todo App
+  description: Full-stack todo app with categories, auth, and Docker local development
+entries:
+  - path: .
+    name: Todo App

--- a/templates/todo-app/rayfin/.env.example
+++ b/templates/todo-app/rayfin/.env.example
@@ -1,0 +1,20 @@
+# Example environment variables for todo-app
+# Copy this file to rayfin/.env and customize values for your environment.
+# `rayfin up` auto-populates most of these values.
+
+# ── Frontend-visible variables (RAYFIN_PUBLIC_*) ───────────────────────
+# Mapped to VITE_* by `rayfin env --framework vite` (run via predev/prebuild).
+
+# Rayfin API Base URL (written by `rayfin up`)
+RAYFIN_PUBLIC_API_URL=http://localhost:5168
+
+# Rayfin Publishable Key (fetched by `rayfin up` from the deployed service)
+RAYFIN_PUBLIC_PUBLISHABLE_KEY=
+
+# Service mode: 'rayfin' (real backend) or 'mock' (local testing)
+RAYFIN_PUBLIC_SERVICE_MODE=rayfin
+
+# Fabric Brokered Authentication (written by `rayfin up`)
+# RAYFIN_PUBLIC_ITEM_ID=<your-rayfin-item-id>
+# RAYFIN_PUBLIC_WORKSPACE_ID=<your-fabric-workspace-id>
+# RAYFIN_PUBLIC_PORTAL_URL=https://app.fabric.microsoft.com

--- a/templates/todo-app/rayfin/data/Category.ts
+++ b/templates/todo-app/rayfin/data/Category.ts
@@ -1,0 +1,18 @@
+import { entity, role, uuid, text, many } from '@microsoft/rayfin-core';
+
+import { Todo } from './Todo.js';
+
+@entity()
+@role('authenticated', '*', {
+  policy: (claims, item) => claims.sub.eq(item.user_id),
+})
+export class Category {
+  @uuid() id!: string;
+  @text() name!: string;
+  @text() color!: string;
+
+  @many(() => Todo)
+  todos?: Todo[];
+
+  @text() user_id!: string;
+}

--- a/templates/todo-app/rayfin/data/Todo.ts
+++ b/templates/todo-app/rayfin/data/Todo.ts
@@ -1,0 +1,38 @@
+import {
+  entity,
+  role,
+  uuid,
+  text,
+  boolean,
+  set,
+  date,
+  one,
+  decimal,
+  int,
+} from '@microsoft/rayfin-core';
+
+import { Category } from './Category.js';
+
+@entity()
+@role('authenticated', '*', {
+  policy: (claims, item) => claims.sub.eq(item.user_id),
+})
+export class Todo {
+  @uuid() id!: string;
+  @text({ min: 1, max: 50 }) Title!: string;
+  @text({ optional: true }) description?: string;
+  @boolean() isCompleted!: boolean;
+  @boolean({ optional: true }) isCompletedOptional?: boolean;
+  @set('low', 'medium', 'high') priority!: 'low' | 'medium' | 'high';
+  @date({ optional: true }) dueDate?: Date;
+  @int({ default: 2 }) points!: number;
+  @int({ optional: true }) optionalPoints?: number;
+  @decimal() percentComplete!: number;
+  @date() createdAt!: Date;
+  @date() updatedAt!: Date;
+
+  @one(() => Category, { optional: true }) category?: Category;
+
+  // User association via user_id populated from JWT claims (not a FK relationship)
+  @text() user_id!: string;
+}

--- a/templates/todo-app/rayfin/data/schema.ts
+++ b/templates/todo-app/rayfin/data/schema.ts
@@ -1,0 +1,20 @@
+import { Category } from './Category.js';
+import { Todo } from './Todo.js';
+
+/**
+ * Schema type definition for the Todo app
+ *
+ * This type maps entity names to their corresponding model types,
+ * enabling full type safety throughout the application when using
+ * the RayfinClient and DataApi.
+ *
+ * Note: User entity is managed by Rayfin's control plane authentication system.
+ * Todo and Category items are associated with users via user_id field
+ * populated from JWT token claims.
+ */
+export type TodoAppSchema = {
+  Todo: Todo;
+  Category: Category;
+};
+
+export const schema = [Todo, Category];

--- a/templates/todo-app/rayfin/rayfin.yml
+++ b/templates/todo-app/rayfin/rayfin.yml
@@ -1,0 +1,23 @@
+id: todo-app
+name: todo-app
+version: 1.0.0
+services:
+  auth:
+    enabled: true
+    fabric:
+      enabled: true
+    password:
+      enabled: true
+    allowedRedirectUris:
+      - http://localhost:5173
+      - http://localhost:5173/auth/callback
+  data:
+    enabled: true
+    dialect: mssql
+  storage:
+    enabled: false
+  staticHosting:
+    enabled: true
+    folder: dist
+    buildCommand: npm run build:fabric
+    indexDocument: index.html

--- a/templates/todo-app/rayfin/storage/ProfileImage.ts
+++ b/templates/todo-app/rayfin/storage/ProfileImage.ts
@@ -1,0 +1,12 @@
+import { blob, role } from '@microsoft/rayfin-core';
+
+@blob()
+@role('authenticated', '*', {
+  policy: (claims, item) => claims.sub.eq(item.owner_id),
+})
+export class ProfileImage {
+  // Storage folders are configured through decorators
+  // Individual files will be managed through the storage API
+
+  owner_id!: string;
+}

--- a/templates/todo-app/rayfin/storage/schema.ts
+++ b/templates/todo-app/rayfin/storage/schema.ts
@@ -1,0 +1,22 @@
+import type { ProfileImage } from './ProfileImage.js';
+
+/**
+ * Storage schema type definition for your Rayfin project
+ *
+ * This type maps storage folder names to their corresponding types,
+ * enabling full type safety throughout the application when using
+ * the RayfinClient and Storage API.
+ *
+ * Add additional storage folders to this schema as you create them:
+ *
+ * ```ts
+ * export type TodoAppStorageSchema = {
+ *   ExampleStorage: ExampleStorage;
+ *   UserUploads: UserUploads;
+ *   Documents: Documents;
+ * };
+ * ```
+ */
+export type TodoAppStorageSchema = {
+  ProfileImage: ProfileImage;
+};

--- a/templates/todo-app/rayfin/tsconfig.json
+++ b/templates/todo-app/rayfin/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "ESNext.Decorators"],
+    "experimentalDecorators": false,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["data", "storage"]
+}

--- a/templates/todo-app/scripts/check-docker-ghcr.mjs
+++ b/templates/todo-app/scripts/check-docker-ghcr.mjs
@@ -1,0 +1,81 @@
+/**
+ * Pre-flight check for Docker local development.
+ *
+ * Verifies that:
+ *  1. Docker is installed and the daemon is running.
+ *  2. The user is authenticated to ghcr.io (GitHub Container Registry)
+ *     so the Rayfin host container image can be pulled.
+ *
+ * Exits non-zero on failure so `npm run dev:local` stops early with
+ * actionable instructions instead of a cryptic Docker pull error.
+ */
+
+import { readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+
+// ── 1. Docker daemon check ──────────────────────────────────────────────────
+
+try {
+  execSync('docker info', { stdio: 'ignore' });
+} catch {
+  console.error('❌ Docker is not running.');
+  console.error('');
+  console.error('   Please start Docker Desktop (or the Docker daemon) and try again.');
+  console.error('   https://www.docker.com/products/docker-desktop/');
+  process.exit(1);
+}
+
+// ── 2. GHCR authentication check ────────────────────────────────────────────
+
+const dockerConfigPath = join(homedir(), '.docker', 'config.json');
+
+let authenticated = false;
+
+try {
+  const raw = await readFile(dockerConfigPath, 'utf-8');
+  const config = JSON.parse(raw);
+
+  const hasAuth = config.auths?.['ghcr.io'] !== undefined;
+  const hasCredHelper = config.credHelpers?.['ghcr.io'] !== undefined;
+
+  authenticated = hasAuth || hasCredHelper;
+} catch {
+  // config.json missing or unreadable — treat as not authenticated
+}
+
+if (authenticated) {
+  console.log('✅ Docker is running and authenticated to ghcr.io');
+  process.exit(0);
+}
+
+// ── Not authenticated — print setup instructions ────────────────────────────
+
+console.error('❌ Not authenticated to ghcr.io (GitHub Container Registry).');
+console.error('');
+console.error('   The Rayfin host container is published to the GitHub private');
+console.error('   package feed. You need to log in to ghcr.io before running');
+console.error('   Docker local development.');
+console.error('');
+console.error('   Option 1 — Use the GitHub CLI (recommended):');
+console.error('');
+console.error('     # Install the GitHub CLI if you haven\'t already');
+console.error('     # https://cli.github.com/');
+console.error('');
+console.error('     # Authenticate (needs read:packages scope)');
+console.error('     gh auth login');
+console.error('     gh auth refresh --scopes read:packages');
+console.error('');
+console.error('     # Pipe the token to Docker login');
+console.error('     gh auth token | docker login ghcr.io -u $(gh api user -q .login) --password-stdin');
+console.error('');
+console.error('   Option 2 — Use a Personal Access Token (classic):');
+console.error('');
+console.error('     # Create a PAT with read:packages scope at');
+console.error('     # https://github.com/settings/tokens');
+console.error('');
+console.error('     echo <YOUR_PAT> | docker login ghcr.io -u <GITHUB_USERNAME> --password-stdin');
+console.error('');
+console.error('   After logging in, re-run:  npm run dev:local');
+process.exit(1);

--- a/templates/todo-app/scripts/run-rayfin-db.js
+++ b/templates/todo-app/scripts/run-rayfin-db.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+
+console.log('🚀 Applying any database schema changes...');
+const child = spawn('npm', ['run', 'rayfin:db'], {
+  stdio: 'inherit',
+  shell: true,
+});
+
+child.on('exit', (code) => {
+  if (code === 0) {
+    process.exit(0);
+  } else {
+    console.error(
+      '\n❌ Failed to run "npm run rayfin:db" that applies any database schema changes.'
+    );
+    console.error(
+      '- See output above for details, and then please check the following:'
+    );
+    console.error('- Is your Rayfin service running?');
+    console.error(
+      '- Have you made any changes to a TypeScript model? If there are any changes that can cause data loss, you need to force apply the changes using the command `npx rayfin up db apply --force`.'
+    );
+    process.exit(code);
+  }
+});

--- a/templates/todo-app/scripts/toggle-service-mode.js
+++ b/templates/todo-app/scripts/toggle-service-mode.js
@@ -1,0 +1,52 @@
+/**
+ * Helper script to toggle between mock and Rayfin service modes
+ * Updates the .env.local file to set VITE_SERVICE_MODE
+ * Run this script before starting the development server
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const envLocalPath = path.resolve('./.env.local');
+
+// Read the current .env.local file
+let envContent = '';
+if (fs.existsSync(envLocalPath)) {
+  envContent = fs.readFileSync(envLocalPath, 'utf-8');
+}
+
+// Determine the desired mode
+const requestedMode = process.argv[2];
+if (!requestedMode || !['mock', 'rayfin'].includes(requestedMode)) {
+  console.error(
+    '❌ Invalid mode. Use: node scripts/toggle-service-mode.js [mock|rayfin]'
+  );
+  process.exit(1);
+}
+
+// Update or add the VITE_SERVICE_MODE line
+const serviceModeRegex = /^VITE_SERVICE_MODE=.*$/m;
+const newServiceModeLine = `VITE_SERVICE_MODE=${requestedMode}`;
+
+if (serviceModeRegex.test(envContent)) {
+  // Replace existing line
+  envContent = envContent.replace(serviceModeRegex, newServiceModeLine);
+} else {
+  // Add new line
+  envContent = envContent.trim();
+  if (envContent) {
+    envContent += '\n';
+  }
+  envContent += `# Service mode override\n${newServiceModeLine}\n`;
+}
+
+// Write the updated content back to the file
+fs.writeFileSync(envLocalPath, envContent);
+
+console.log(`✅ Service mode set to '${requestedMode}' in .env.local`);
+console.log(
+  `🚀 Now you can run 'npm run dev' to start the development server in ${requestedMode} mode.`
+);
+console.log(
+  `💡 Tip: You can also set VITE_RAYFIN_API_URL in .env.local to customize the API endpoint.`
+);

--- a/templates/todo-app/src/App.tsx
+++ b/templates/todo-app/src/App.tsx
@@ -1,0 +1,48 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+
+import { AuthPage } from './components/AuthPage';
+import { useAuth } from './hooks/AuthContext';
+import { AuthCallback } from './pages/AuthCallback';
+import { Dashboard } from './pages/Dashboard';
+import { VerifyEmail } from './pages/VerifyEmail';
+
+function App() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* Public routes */}
+        <Route path="/verify-email" element={<VerifyEmail />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route
+          path="/login"
+          element={user ? <Navigate to="/" replace /> : <AuthPage />}
+        />
+        <Route
+          path="/reset-password"
+          element={user ? <Navigate to="/" replace /> : <AuthPage />}
+        />
+
+        {/* Protected routes */}
+        <Route
+          path="/"
+          element={user ? <Dashboard /> : <Navigate to="/login" replace />}
+        />
+
+        {/* Catch all - redirect to home */}
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/templates/todo-app/src/__tests__/setup.ts
+++ b/templates/todo-app/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/templates/todo-app/src/components/AuthPage.tsx
+++ b/templates/todo-app/src/components/AuthPage.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react';
+
+import { useAuthSettings } from '../hooks/AuthSettingsContext';
+
+import { FabricLoginButton } from './FabricLoginButton';
+import { ForgotPassword } from './ForgotPassword';
+import { LoginForm } from './LoginForm';
+import { MagicLinkForm } from './MagicLinkForm';
+import { ResetPassword } from './ResetPassword';
+import { SignupForm } from './SignupForm';
+
+type AuthView =
+  | 'login'
+  | 'signup'
+  | 'forgot-password'
+  | 'reset-password'
+  | 'magic-link';
+
+export function AuthPage() {
+  const {
+    isPasswordAuthAvailable,
+    isMagicLinkAuthAvailable,
+    isFabricAuthAvailable,
+    loading,
+  } = useAuthSettings();
+
+  const [currentView, setCurrentView] = useState<AuthView>('login');
+  const [resetToken, setResetToken] = useState<string | null>(null);
+
+  // Update default view when auth settings are loaded
+  useEffect(() => {
+    if (!loading) {
+      // Show login if password auth is available, otherwise magic link if available
+      if (isPasswordAuthAvailable) {
+        setCurrentView('login');
+      } else if (isMagicLinkAuthAvailable) {
+        setCurrentView('magic-link');
+      }
+    }
+  }, [loading, isPasswordAuthAvailable, isMagicLinkAuthAvailable]);
+
+  // Check for password reset token in URL on mount
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const token = urlParams.get('resetToken');
+    if (token && isPasswordAuthAvailable) {
+      setResetToken(token);
+      setCurrentView('reset-password');
+    }
+  }, [isPasswordAuthAvailable]);
+
+  const handleBackToLogin = () => {
+    if (isPasswordAuthAvailable) {
+      setCurrentView('login');
+    } else if (isMagicLinkAuthAvailable) {
+      setCurrentView('magic-link');
+    }
+    setResetToken(null);
+    // Clear reset token from URL if present
+    if (window.location.search.includes('resetToken')) {
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
+  };
+
+  const toggleSignup = () => {
+    setCurrentView(currentView === 'signup' ? 'login' : 'signup');
+  };
+
+  const showForgotPassword = () => {
+    setCurrentView('forgot-password');
+  };
+
+  const showMagicLink = () => {
+    setCurrentView('magic-link');
+  };
+
+  const showPasswordLogin = () => {
+    setCurrentView('login');
+  };
+
+  // Show loading state while fetching auth settings
+  if (loading) {
+    return (
+      <div className="min-h-screen flex flex-col justify-start items-center bg-gray-50 pt-16">
+        <div className="max-w-md w-full text-center">
+          <div className="animate-pulse text-gray-500">Loading...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col justify-start items-center bg-gray-50 pt-16">
+      <div className="max-w-md w-full">
+        {/* Password-based authentication views */}
+        {isPasswordAuthAvailable && currentView === 'signup' && (
+          <SignupForm onToggleForm={toggleSignup} />
+        )}
+        {isPasswordAuthAvailable && currentView === 'login' && (
+          <LoginForm
+            onToggleForm={toggleSignup}
+            onForgotPassword={showForgotPassword}
+            onMagicLink={isMagicLinkAuthAvailable ? showMagicLink : undefined}
+            fabricButton={
+              isFabricAuthAvailable ? <FabricLoginButton /> : undefined
+            }
+          />
+        )}
+        {isPasswordAuthAvailable && currentView === 'forgot-password' && (
+          <ForgotPassword onBackToLogin={handleBackToLogin} />
+        )}
+        {isPasswordAuthAvailable &&
+          currentView === 'reset-password' &&
+          resetToken && (
+            <ResetPassword
+              token={resetToken}
+              onBackToLogin={handleBackToLogin}
+            />
+          )}
+
+        {/* Magic link authentication */}
+        {isMagicLinkAuthAvailable && currentView === 'magic-link' && (
+          <MagicLinkForm
+            onBackToLogin={
+              isPasswordAuthAvailable ? showPasswordLogin : undefined
+            }
+            fabricButton={
+              isFabricAuthAvailable ? <FabricLoginButton /> : undefined
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/AuthStateObserver.tsx
+++ b/templates/todo-app/src/components/AuthStateObserver.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+import { getRayfinClient } from '../services/rayfin/RayfinClientService';
+
+interface AuthStateObserverProps {
+  onAuthStateChange: (isAuthenticated: boolean) => void;
+}
+
+export function AuthStateObserver({
+  onAuthStateChange,
+}: AuthStateObserverProps) {
+  useEffect(() => {
+    // Only run in Rayfin mode
+    const serviceMode = import.meta.env.VITE_SERVICE_MODE || 'rayfin';
+    if (serviceMode === 'mock') {
+      console.log('AuthStateObserver: Skipping in mock mode');
+      return () => {};
+    }
+
+    try {
+      const rayfinClient = getRayfinClient();
+
+      // Subscribe to session changes from RayfinClient
+      const unsubscribe = rayfinClient.auth.onSessionChange((session) => {
+        console.log('AuthStateObserver: Session changed:', !!session);
+        onAuthStateChange(!!session);
+      });
+
+      // Clean up subscription on unmount
+      return () => {
+        unsubscribe();
+      };
+    } catch (error) {
+      console.warn('AuthStateObserver: RayfinClient not initialized', error);
+      return () => {};
+    }
+  }, [onAuthStateChange]);
+
+  // This component doesn't render anything
+  return null;
+}

--- a/templates/todo-app/src/components/CategoryBadge.tsx
+++ b/templates/todo-app/src/components/CategoryBadge.tsx
@@ -1,0 +1,68 @@
+import { Category } from '../../rayfin/data/Category';
+
+interface CategoryBadgeProps {
+  category: Category;
+  size?: 'sm' | 'md';
+  showRemove?: boolean;
+  onRemove?: () => void;
+  className?: string;
+}
+
+export function CategoryBadge({
+  category,
+  size = 'sm',
+  showRemove = false,
+  onRemove,
+  className = '',
+}: CategoryBadgeProps) {
+  const sizeClasses = {
+    sm: 'px-2.5 py-0.5 text-xs font-medium', // Match priority badge styling
+    md: 'px-3 py-1.5 text-sm',
+  };
+
+  const textColor = getContrastColor(category.color);
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full font-medium ${sizeClasses[size]} ${className}`}
+      style={{
+        backgroundColor: category.color,
+        color: textColor,
+      }}
+    >
+      {category.name}
+      {showRemove && onRemove && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="ml-1.5 hover:opacity-75 focus:outline-none"
+          aria-label={`Remove ${category.name} category`}
+        >
+          <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fillRule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+}
+
+// Utility function to determine if text should be light or dark based on background color
+function getContrastColor(hexColor: string): string {
+  // Convert hex to RGB
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+
+  // Calculate luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+  // Return black or white based on luminance
+  return luminance > 0.5 ? '#000000' : '#FFFFFF';
+}

--- a/templates/todo-app/src/components/CategoryFilter.tsx
+++ b/templates/todo-app/src/components/CategoryFilter.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+
+import { Category } from '../../rayfin/data/Category';
+import { TodoFilters } from '../hooks/useTodos';
+
+import { CategoryBadge } from './CategoryBadge';
+
+interface CategoryFilterProps {
+  categories: Category[];
+  allTodos: any[]; // All todos for counting purposes
+  filters: TodoFilters;
+  onFiltersChange: (filters: TodoFilters) => void;
+}
+
+export function CategoryFilter({
+  categories,
+  allTodos,
+  filters,
+  onFiltersChange,
+}: CategoryFilterProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Count todos per category
+  const getCategoryCount = (categoryId: string) => {
+    return allTodos.filter((todo) => todo.category?.id === categoryId).length;
+  };
+
+  const getUncategorizedCount = () => {
+    return allTodos.filter((todo) => !todo.category).length;
+  };
+
+  const handleCategoryToggle = (categoryId: string) => {
+    const newCategoryIds = filters.categoryIds.includes(categoryId)
+      ? filters.categoryIds.filter((id) => id !== categoryId)
+      : [...filters.categoryIds, categoryId];
+
+    onFiltersChange({
+      ...filters,
+      categoryIds: newCategoryIds,
+    });
+  };
+
+  const handleUncategorizedToggle = () => {
+    onFiltersChange({
+      ...filters,
+      includeUncategorized: !filters.includeUncategorized,
+    });
+  };
+
+  const handleSelectAll = () => {
+    onFiltersChange({
+      categoryIds: categories.map((c) => c.id),
+      includeUncategorized: true,
+    });
+  };
+
+  const handleClearAll = () => {
+    onFiltersChange({
+      categoryIds: [],
+      includeUncategorized: false,
+    });
+  };
+
+  const activeFilterCount =
+    filters.categoryIds.length + (filters.includeUncategorized ? 1 : 0);
+  const hasActiveFilters = activeFilterCount > 0;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 mb-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <h3 className="text-sm font-medium text-gray-900">
+            Filter by Category
+          </h3>
+          {hasActiveFilters && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+              {activeFilterCount} active
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center space-x-2">
+          {hasActiveFilters && (
+            <button
+              onClick={handleClearAll}
+              className="text-xs text-gray-500 hover:text-gray-700 underline"
+            >
+              Clear all
+            </button>
+          )}
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-gray-400 hover:text-gray-600 focus:outline-none"
+          >
+            <svg
+              className={`w-5 h-5 transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Show active filters when collapsed */}
+      {!isExpanded && hasActiveFilters && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {filters.categoryIds.map((categoryId) => {
+            const category = categories.find((c) => c.id === categoryId);
+            if (!category) return null;
+            return (
+              <CategoryBadge
+                key={categoryId}
+                category={category}
+                size="sm"
+                showRemove
+                onRemove={() => handleCategoryToggle(categoryId)}
+              />
+            );
+          })}
+          {filters.includeUncategorized && (
+            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-200 text-gray-800">
+              Uncategorized
+              <button
+                onClick={handleUncategorizedToggle}
+                className="ml-1.5 hover:opacity-75 focus:outline-none"
+              >
+                <svg
+                  className="w-3 h-3"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Expanded filter options */}
+      {isExpanded && (
+        <div className="mt-4 space-y-3">
+          <div className="flex justify-between">
+            <button
+              onClick={handleSelectAll}
+              className="text-xs text-blue-600 hover:text-blue-800 underline"
+            >
+              Select all
+            </button>
+            <button
+              onClick={handleClearAll}
+              className="text-xs text-gray-500 hover:text-gray-700 underline"
+            >
+              Clear all
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            {/* Categories */}
+            {categories.map((category) => {
+              const count = getCategoryCount(category.id);
+              const isSelected = filters.categoryIds.includes(category.id);
+
+              return (
+                <label
+                  key={category.id}
+                  className="flex items-center space-x-2 p-2 rounded hover:bg-gray-50 cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => handleCategoryToggle(category.id)}
+                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <CategoryBadge category={category} size="sm" />
+                  <span className="text-sm text-gray-500">({count})</span>
+                </label>
+              );
+            })}
+
+            {/* Uncategorized */}
+            <label className="flex items-center space-x-2 p-2 rounded hover:bg-gray-50 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={filters.includeUncategorized}
+                onChange={handleUncategorizedToggle}
+                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-200 text-gray-800">
+                Uncategorized
+              </span>
+              <span className="text-sm text-gray-500">
+                ({getUncategorizedCount()})
+              </span>
+            </label>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/CategoryManager.tsx
+++ b/templates/todo-app/src/components/CategoryManager.tsx
@@ -1,0 +1,347 @@
+import { useState, useRef, useEffect } from 'react';
+
+import { Category } from '../../rayfin/data/Category';
+
+import { CategoryBadge } from './CategoryBadge';
+
+interface CategoryManagerProps {
+  categories: Category[];
+  selectedCategory?: Category;
+  onCategorySelect: (category: Category | undefined) => void;
+  onCategoryCreate: (category: {
+    name: string;
+    color?: string;
+  }) => Promise<Category>;
+  onCategoryUpdate: (
+    id: string,
+    updates: { name?: string; color?: string }
+  ) => Promise<Category>;
+  onCategoryDelete: (id: string) => Promise<void>;
+  disabled?: boolean;
+}
+
+export function CategoryManager({
+  categories,
+  selectedCategory,
+  onCategorySelect,
+  onCategoryCreate,
+  onCategoryUpdate,
+  onCategoryDelete,
+  disabled = false,
+}: CategoryManagerProps) {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const [selectedColor, setSelectedColor] = useState('#3B82F6');
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Predefined color options
+  const colorOptions = [
+    '#3B82F6', // Blue
+    '#10B981', // Green
+    '#8B5CF6', // Purple
+    '#EF4444', // Red
+    '#F59E0B', // Amber
+    '#06B6D4', // Cyan
+    '#84CC16', // Lime
+    '#EC4899', // Pink
+  ];
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowDropdown(false);
+        setIsCreating(false);
+        setEditingId(null);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Focus input when creating or editing
+  useEffect(() => {
+    if ((isCreating || editingId) && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isCreating, editingId]);
+
+  const handleCreateCategory = async () => {
+    if (!newCategoryName.trim()) return;
+
+    try {
+      const newCategory = await onCategoryCreate({
+        name: newCategoryName.trim(),
+        color: selectedColor,
+      });
+      onCategorySelect(newCategory);
+      setNewCategoryName('');
+      setIsCreating(false);
+      setShowDropdown(false);
+    } catch (err) {
+      console.error('Failed to create category:', err);
+    }
+  };
+
+  const handleUpdateCategory = async (id: string) => {
+    if (!editingName.trim()) return;
+
+    try {
+      const updatedCategory = await onCategoryUpdate(id, {
+        name: editingName.trim(),
+      });
+      if (selectedCategory?.id === id) {
+        onCategorySelect(updatedCategory);
+      }
+      setEditingId(null);
+      setEditingName('');
+    } catch (err) {
+      console.error('Failed to update category:', err);
+    }
+  };
+
+  const handleDeleteCategory = async (id: string) => {
+    if (
+      !confirm(
+        'Are you sure you want to delete this category? Todos in this category will become uncategorized.'
+      )
+    ) {
+      return;
+    }
+
+    try {
+      await onCategoryDelete(id);
+      if (selectedCategory?.id === id) {
+        onCategorySelect(undefined);
+      }
+    } catch (err) {
+      console.error('Failed to delete category:', err);
+    }
+  };
+
+  const startEditing = (category: Category) => {
+    setEditingId(category.id);
+    setEditingName(category.name);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        Category
+      </label>
+
+      <button
+        type="button"
+        onClick={() => setShowDropdown(!showDropdown)}
+        disabled={disabled}
+        className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm flex items-center justify-between hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        style={{ border: '1px solid #000' }}
+      >
+        <div className="flex items-center">
+          {selectedCategory ? (
+            <CategoryBadge category={selectedCategory} size="sm" />
+          ) : (
+            <span className="text-gray-500">Select a category...</span>
+          )}
+        </div>
+        <svg
+          className="w-4 h-4 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {showDropdown && (
+        <div className="absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+          {/* No category option */}
+          <button
+            type="button"
+            onClick={() => {
+              onCategorySelect(undefined);
+              setShowDropdown(false);
+            }}
+            className="w-full px-3 py-2 text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-50 border-b border-gray-100"
+          >
+            <span className="text-gray-700 font-medium">No category</span>
+          </button>
+
+          {/* Existing categories */}
+          {categories.map((category) => (
+            <div key={category.id} className="flex items-center group">
+              {editingId === category.id ? (
+                <div className="flex-1 p-2">
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={editingName}
+                    onChange={(e) => setEditingName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        handleUpdateCategory(category.id);
+                      } else if (e.key === 'Escape') {
+                        setEditingId(null);
+                        setEditingName('');
+                      }
+                    }}
+                    onBlur={() => handleUpdateCategory(category.id)}
+                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  />
+                </div>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onCategorySelect(category);
+                      setShowDropdown(false);
+                    }}
+                    className="flex-1 px-3 py-2 text-left hover:bg-gray-50 focus:outline-none focus:bg-gray-50"
+                  >
+                    <CategoryBadge category={category} size="sm" />
+                  </button>
+                  <div className="opacity-0 group-hover:opacity-100 flex px-2">
+                    <button
+                      type="button"
+                      onClick={() => startEditing(category)}
+                      className="p-1 hover:bg-gray-100 rounded text-gray-500 hover:text-gray-700"
+                      title="Rename category"
+                    >
+                      <svg
+                        className="w-3 h-3"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteCategory(category.id)}
+                      className="p-1 hover:bg-gray-100 rounded text-gray-500 hover:text-red-600"
+                      title="Delete category"
+                    >
+                      <svg
+                        className="w-3 h-3"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+
+          {/* Create new category */}
+          <div className="border-t border-gray-100">
+            {isCreating ? (
+              <div className="p-3 space-y-3">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  placeholder="Category name"
+                  value={newCategoryName}
+                  onChange={(e) => setNewCategoryName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleCreateCategory();
+                    } else if (e.key === 'Escape') {
+                      setIsCreating(false);
+                      setNewCategoryName('');
+                    }
+                  }}
+                  className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+                <div className="flex flex-wrap gap-1">
+                  {colorOptions.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      onClick={() => setSelectedColor(color)}
+                      className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${selectedColor === color ? 'border-gray-400' : 'border-gray-200'}`}
+                      style={{ backgroundColor: color }}
+                      title={`Select color ${color}`}
+                    >
+                      {selectedColor === color && (
+                        <svg
+                          className="w-3 h-3 text-white"
+                          fill="currentColor"
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      )}
+                    </button>
+                  ))}
+                </div>
+                <div className="flex space-x-2">
+                  <button
+                    type="button"
+                    onClick={handleCreateCategory}
+                    disabled={!newCategoryName.trim()}
+                    className="flex-1 px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Create
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsCreating(false);
+                      setNewCategoryName('');
+                    }}
+                    className="flex-1 px-3 py-1 text-xs bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsCreating(true)}
+                className="w-full px-3 py-2 text-left text-blue-600 hover:bg-blue-50 focus:outline-none focus:bg-blue-50"
+              >
+                <span className="text-sm">+ Create new category</span>
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/FabricLoginButton.tsx
+++ b/templates/todo-app/src/components/FabricLoginButton.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+import { useAuth } from '../hooks/AuthContext';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+export function FabricLoginButton() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { refreshUser } = useAuth();
+
+  const handleClick = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const authService = ServiceContainer.create().authService;
+      await authService.ensureSignedInWithFabric();
+      // The 4-step waterfall has resolved — session is established.
+      // Refresh React auth state to pick up the new session.
+      await refreshUser();
+    } catch (err) {
+      console.error('Fabric login error:', err);
+      setError(
+        err instanceof Error ? err.message : 'Failed to sign in with Fabric.'
+      );
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 items-center gap-2"
+      >
+        {loading ? 'Opening Fabric...' : 'Sign in with Fabric'}
+      </button>
+      {error && (
+        <p className="mt-2 text-sm text-red-600 text-center">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/ForgotPassword.tsx
+++ b/templates/todo-app/src/components/ForgotPassword.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+
+import { getRayfinClient } from '../services/rayfin/RayfinClientService';
+
+interface ForgotPasswordProps {
+  onBackToLogin: () => void;
+}
+
+export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const client = getRayfinClient();
+      const result = await client.auth.requestPasswordReset(email);
+
+      if (result.success) {
+        setSuccess(true);
+      } else {
+        setError(result.message || 'Failed to send reset email');
+      }
+    } catch (err: any) {
+      console.error('Password reset request error:', err);
+      setError(err.message || 'Failed to send reset email. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow-md">
+        <div className="text-center mb-6">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mb-4">
+            <svg
+              className="w-10 h-10 text-blue-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Check Your Email
+          </h2>
+          <p className="text-gray-600 mb-4">
+            If an account exists with <strong>{email}</strong>, we've sent a
+            password reset link to that address.
+          </p>
+          <p className="text-sm text-gray-600">
+            Please check your inbox and follow the instructions to reset your
+            password.
+          </p>
+        </div>
+        <button
+          onClick={onBackToLogin}
+          className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          Back to Sign In
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 bg-white rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold mb-2 text-center">Reset Password</h2>
+      <p className="text-gray-600 mb-6 text-center text-sm">
+        Enter your email address and we'll send you a link to reset your
+        password.
+      </p>
+
+      {error && (
+        <div className="p-3 mb-4 text-sm text-red-700 bg-red-100 rounded-lg">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <div className="mb-6">
+          <label
+            htmlFor="email"
+            className="block text-gray-700 font-medium mb-2"
+          >
+            Email Address
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="you@example.com"
+            required
+            disabled={loading}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 mb-3"
+        >
+          {loading ? 'Sending...' : 'Send Reset Link'}
+        </button>
+
+        <button
+          type="button"
+          onClick={onBackToLogin}
+          className="w-full text-gray-600 hover:text-gray-800 text-sm"
+        >
+          Back to Sign In
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/LoginForm.tsx
+++ b/templates/todo-app/src/components/LoginForm.tsx
@@ -1,0 +1,257 @@
+import { useState, useEffect, ReactNode } from 'react';
+
+import { useAuth } from '../hooks/AuthContext';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+interface LoginFormProps {
+  onToggleForm: () => void;
+  onForgotPassword: () => void;
+  onMagicLink?: () => void;
+  fabricButton?: ReactNode;
+}
+
+const COOLDOWN_KEY = 'resendVerificationCooldown';
+const COOLDOWN_SECONDS = 30;
+
+export function LoginForm({
+  onToggleForm,
+  onForgotPassword,
+  onMagicLink,
+  fabricButton,
+}: LoginFormProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [resendLoading, setResendLoading] = useState(false);
+  const [resendMessage, setResendMessage] = useState<string | null>(null);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const { login, loading, error } = useAuth();
+
+  // Initialize cooldown from localStorage on mount
+  useEffect(() => {
+    const cooldownEnd = localStorage.getItem(COOLDOWN_KEY);
+    if (cooldownEnd) {
+      const remaining = Math.max(
+        0,
+        Math.floor((parseInt(cooldownEnd) - Date.now()) / 1000)
+      );
+      if (remaining > 0) {
+        setResendCooldown(remaining);
+      } else {
+        localStorage.removeItem(COOLDOWN_KEY);
+      }
+    }
+  }, []);
+
+  // Cooldown timer effect
+  useEffect(() => {
+    if (resendCooldown > 0) {
+      const timer = setTimeout(() => {
+        const newCooldown = resendCooldown - 1;
+        setResendCooldown(newCooldown);
+        if (newCooldown === 0) {
+          localStorage.removeItem(COOLDOWN_KEY);
+        }
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [resendCooldown]);
+
+  const handleResendVerification = async () => {
+    if (!email) {
+      setResendMessage('Please enter your email address first.');
+      return;
+    }
+
+    if (resendCooldown > 0) {
+      setResendMessage(
+        `Please wait ${resendCooldown} seconds before resending.`
+      );
+      return;
+    }
+
+    setResendMessage(null);
+    setResendLoading(true);
+
+    try {
+      const result =
+        await ServiceContainer.create().authService.resendVerificationEmail(
+          email
+        );
+      setResendMessage(result.message);
+      const cooldownEnd = Date.now() + COOLDOWN_SECONDS * 1000;
+      localStorage.setItem(COOLDOWN_KEY, cooldownEnd.toString());
+      setResendCooldown(COOLDOWN_SECONDS);
+    } catch (err) {
+      console.error('Resend verification error:', err);
+      setResendMessage(
+        err instanceof Error
+          ? err.message
+          : 'Failed to resend verification email'
+      );
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log('LoginForm: Starting login process...');
+    try {
+      const result = await login(email, password);
+      console.log('LoginForm: Login completed successfully, result:', result);
+      // Login success - useAuth hook will handle the state update and UI refresh
+    } catch (err) {
+      console.error('LoginForm: Login failed:', err);
+      // Error handled in useAuth hook
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col justify-start items-center bg-gray-50 pt-16">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Sign in to Todo App
+          </h2>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              <p>{error}</p>
+              {error.toLowerCase().includes('verify your email') && (
+                <button
+                  type="button"
+                  onClick={handleResendVerification}
+                  disabled={resendLoading || resendCooldown > 0}
+                  className="mt-2 text-sm text-blue-600 hover:text-blue-800 underline disabled:opacity-50"
+                >
+                  {resendLoading
+                    ? 'Resending...'
+                    : resendCooldown > 0
+                      ? `Resend in ${resendCooldown}s`
+                      : 'Resend verification email'}
+                </button>
+              )}
+            </div>
+          )}
+          {resendMessage && (
+            <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded">
+              {resendMessage}
+            </div>
+          )}
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              required
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              required
+            />
+            <div className="mt-1 text-right">
+              <button
+                type="button"
+                onClick={onForgotPassword}
+                className="text-sm text-blue-600 hover:text-blue-800"
+              >
+                Forgot password?
+              </button>
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            {loading ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+
+        {/* Divider with magic link option */}
+        {onMagicLink && (
+          <>
+            <div className="mt-6 relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-gray-50 text-gray-500">
+                  Or continue with
+                </span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={onMagicLink}
+              className="mt-4 w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              <svg
+                className="w-5 h-5 mr-2"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+              Sign in with magic link
+            </button>
+          </>
+        )}
+
+        {fabricButton && (
+          <>
+            <div className="mt-6 relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-gray-50 text-gray-500">
+                  Or continue with
+                </span>
+              </div>
+            </div>
+            <div className="mt-4">{fabricButton}</div>
+          </>
+        )}
+
+        <div className="mt-4 text-center">
+          <button
+            onClick={onToggleForm}
+            className="text-blue-500 hover:text-blue-700"
+          >
+            Need an account? Sign up
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/MagicLinkForm.tsx
+++ b/templates/todo-app/src/components/MagicLinkForm.tsx
@@ -1,0 +1,176 @@
+import { useState, ReactNode } from 'react';
+
+import { ServiceContainer } from '../services/ServiceContainer';
+
+interface MagicLinkFormProps {
+  onBackToLogin?: () => void;
+  fabricButton?: ReactNode;
+}
+
+export function MagicLinkForm({
+  onBackToLogin,
+  fabricButton,
+}: MagicLinkFormProps) {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const authService = ServiceContainer.create().authService;
+      // Use current origin + /auth/callback as the redirect URI
+      const redirectUri = `${window.location.origin}/auth/callback`;
+
+      const result = await authService.sendMagicLink(email, redirectUri);
+
+      if (result.success) {
+        setSuccess(true);
+      } else {
+        setError('Failed to send magic link. Please try again.');
+      }
+    } catch (err) {
+      console.error('Magic link error:', err);
+      setError(
+        err instanceof Error ? err.message : 'Failed to send magic link'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Success state - show email sent confirmation
+  if (success) {
+    return (
+      <div className="min-h-screen flex flex-col justify-start items-center bg-gray-50 pt-16">
+        <div className="max-w-md w-full space-y-8">
+          <div className="p-6 bg-white rounded-lg shadow-md">
+            <div className="text-center mb-6">
+              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mb-4">
+                <svg
+                  className="w-10 h-10 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                Check your email
+              </h2>
+              <p className="text-gray-600 mb-4">We sent a sign-in link to:</p>
+              <p className="text-lg font-medium text-gray-900 mb-4">{email}</p>
+              <p className="text-sm text-gray-600">
+                Click the link in the email to sign in. The link will expire in
+                15 minutes.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <button
+                onClick={() => {
+                  setSuccess(false);
+                  setEmail('');
+                }}
+                className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+              >
+                Try a different email
+              </button>
+              {onBackToLogin && (
+                <button
+                  onClick={onBackToLogin}
+                  className="w-full text-blue-500 hover:text-blue-700 font-medium py-2"
+                >
+                  Back to sign in options
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col justify-start items-center bg-gray-50 pt-16">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Sign in with email
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            We'll send you a magic link to sign in instantly
+          </p>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              <p>{error}</p>
+            </div>
+          )}
+          <div>
+            <label
+              htmlFor="magic-link-email"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Email address
+            </label>
+            <input
+              id="magic-link-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              placeholder="you@example.com"
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            {loading ? 'Sending...' : 'Send magic link'}
+          </button>
+        </form>
+
+        {fabricButton && (
+          <>
+            <div className="mt-6 relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-gray-50 text-gray-500">
+                  Or continue with
+                </span>
+              </div>
+            </div>
+            <div className="mt-4">{fabricButton}</div>
+          </>
+        )}
+
+        {onBackToLogin && (
+          <div className="mt-4 text-center">
+            <button
+              onClick={onBackToLogin}
+              className="text-blue-500 hover:text-blue-700"
+            >
+              Back to sign in options
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/ProfileImage.tsx
+++ b/templates/todo-app/src/components/ProfileImage.tsx
@@ -1,0 +1,65 @@
+import { useProfileImage } from '../hooks/useProfileImage';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+interface ProfileImageProps {
+  userId: string;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  className?: string;
+  alt?: string;
+  onClick?: () => void;
+  clickable?: boolean;
+}
+
+const sizeClasses = {
+  sm: 'w-8 h-8',
+  md: 'w-12 h-12',
+  lg: 'w-16 h-16',
+  xl: 'w-24 h-24',
+};
+
+/**
+ * Component for displaying a user's profile image with fallback to default avatar
+ */
+export function ProfileImage({
+  userId,
+  size = 'md',
+  className = '',
+  alt,
+  onClick,
+  clickable = false,
+}: ProfileImageProps) {
+  const { getDisplayUrl, error } = useProfileImage(userId);
+
+  const sizeClass = sizeClasses[size];
+  const displayUrl = getDisplayUrl();
+
+  if (error) {
+    console.warn('Profile image error:', error);
+  }
+
+  const handleClick = () => {
+    if (clickable && onClick) {
+      onClick();
+    }
+  };
+
+  return (
+    <img
+      src={displayUrl}
+      alt={alt || 'Profile image'}
+      className={`${
+        sizeClass
+      } rounded-full object-cover border-2 border-gray-200 ${
+        clickable ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''
+      } ${className}`}
+      onClick={handleClick}
+      onError={(e) => {
+        // If the image fails to load, fall back to default avatar
+        const target = e.target as HTMLImageElement;
+        const profileImageService =
+          ServiceContainer.create().profileImageService;
+        target.src = profileImageService.getDefaultAvatar();
+      }}
+    />
+  );
+}

--- a/templates/todo-app/src/components/ProfileImageModal.tsx
+++ b/templates/todo-app/src/components/ProfileImageModal.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useState } from 'react';
+
+import { useProfileImage } from '../hooks/useProfileImage';
+
+import { ProfileImageUpload } from './ProfileImageUpload';
+
+interface ProfileImageModalProps {
+  userId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Modal for updating profile images with deferred upload
+ */
+export function ProfileImageModal({
+  userId,
+  isOpen,
+  onClose,
+}: ProfileImageModalProps) {
+  const { uploadProfileImage, isLoading, error } = useProfileImage(userId);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const handleImageSelected = useCallback((file: File) => {
+    setSelectedFile(file);
+    setUploadError(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!selectedFile) return;
+
+    try {
+      setUploadError(null);
+      await uploadProfileImage(userId, selectedFile);
+
+      // Dispatch event to notify other components of the update
+      window.dispatchEvent(
+        new CustomEvent('profile-image-updated', {
+          detail: { userId },
+        })
+      );
+
+      // Reset state and close modal
+      setSelectedFile(null);
+      onClose();
+    } catch (err) {
+      setUploadError(
+        err instanceof Error ? err.message : 'Failed to upload image'
+      );
+    }
+  }, [selectedFile, userId, uploadProfileImage, onClose]);
+
+  const handleClose = useCallback(() => {
+    setSelectedFile(null);
+    setUploadError(null);
+    onClose();
+  }, [onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            Update Profile Image
+          </h2>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
+            disabled={isLoading}
+          >
+            ×
+          </button>
+        </div>
+
+        <ProfileImageUpload
+          userId={userId}
+          onImageSelected={handleImageSelected}
+          className="mb-4"
+        />
+
+        {uploadError && (
+          <div className="text-sm text-red-600 text-center mb-4">
+            {uploadError}
+          </div>
+        )}
+
+        {error && (
+          <div className="text-sm text-red-600 text-center mb-4">{error}</div>
+        )}
+
+        <div className="flex justify-end space-x-3">
+          <button
+            onClick={handleClose}
+            disabled={isLoading}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isLoading || !selectedFile}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/ProfileImageUpload.tsx
+++ b/templates/todo-app/src/components/ProfileImageUpload.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useState } from 'react';
+
+import { useProfileImage } from '../hooks/useProfileImage';
+
+interface ProfileImageUploadProps {
+  /**
+   * Optional userId for showing the current persisted image during signup.
+   * When undefined, component falls back to default avatar until a preview is selected.
+   */
+  userId?: string;
+  /**
+   * Deferred selection callback. Called after validation with the selected file and its preview URL.
+   */
+  onImageSelected?: (file: File, previewUrl: string) => void;
+  className?: string;
+}
+
+/**
+ * Component for uploading profile images with drag-and-drop support and preview
+ */
+export function ProfileImageUpload({
+  userId,
+  onImageSelected,
+  className = '',
+}: ProfileImageUploadProps) {
+  // Note: In deferred mode, we only read existing image (if userId provided) and never upload here.
+  const {
+    isLoading,
+    error: loadError,
+    getDisplayUrl,
+  } = useProfileImage(userId);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleFileChange = useCallback(
+    async (file: File | null) => {
+      if (!file) {
+        setPreviewUrl(null);
+        setValidationError(null);
+        return;
+      }
+
+      // Validate basic constraints here for fast feedback
+      const allowed = [
+        'image/jpeg',
+        'image/jpg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+      ];
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (!allowed.includes(file.type)) {
+        setValidationError(
+          'Please select a valid image file (JPEG, PNG, GIF, or WebP)'
+        );
+        setPreviewUrl(null);
+        return;
+      }
+      if (file.size > maxSize) {
+        setValidationError('Image file must be smaller than 2MB');
+        setPreviewUrl(null);
+        return;
+      }
+
+      setValidationError(null);
+
+      try {
+        // Show preview immediately
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const url = e.target?.result as string;
+          setPreviewUrl(url);
+          onImageSelected?.(file, url);
+        };
+        reader.readAsDataURL(file);
+      } catch (err) {
+        setValidationError('Failed to read image file');
+        setPreviewUrl(null);
+      }
+    },
+    [onImageSelected]
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    handleFileChange(file);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (file && file.type.startsWith('image/')) {
+      handleFileChange(file);
+    }
+  };
+
+  const currentImageUrl = previewUrl || getDisplayUrl();
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      {/* Current/Preview Image */}
+      <div className="flex justify-center">
+        <img
+          src={currentImageUrl}
+          alt="Profile preview"
+          className="w-24 h-24 rounded-full object-cover border-2 border-gray-200"
+        />
+      </div>
+
+      {/* Upload Area */}
+      <div
+        className={`
+          border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer
+          ${
+            isDragOver
+              ? 'border-blue-400 bg-blue-50'
+              : 'border-gray-300 hover:border-gray-400'
+          }
+          ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}
+        `}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={() => document.getElementById('profile-image-input')?.click()}
+      >
+        <input
+          id="profile-image-input"
+          type="file"
+          accept="image/*"
+          onChange={handleInputChange}
+          className="hidden"
+          disabled={isLoading}
+        />
+
+        <div className="space-y-2">
+          <svg
+            className="mx-auto h-12 w-12 text-gray-400"
+            stroke="currentColor"
+            fill="none"
+            viewBox="0 0 48 48"
+          >
+            <path
+              d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <div className="text-sm text-gray-600">
+            {isLoading ? (
+              <p>Uploading...</p>
+            ) : (
+              <>
+                <p>
+                  <span className="font-medium text-blue-600 hover:text-blue-500">
+                    Click to upload
+                  </span>{' '}
+                  or drag and drop
+                </p>
+                <p className="text-xs">PNG, JPG, GIF up to 2MB</p>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Error Messages */}
+      {validationError && (
+        <div className="text-sm text-red-600 text-center">
+          {validationError}
+        </div>
+      )}
+      {loadError && (
+        <div className="text-sm text-red-600 text-center">{loadError}</div>
+      )}
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/ResetPassword.tsx
+++ b/templates/todo-app/src/components/ResetPassword.tsx
@@ -1,0 +1,224 @@
+import { useState, useEffect } from 'react';
+
+import { getRayfinClient } from '../services/rayfin/RayfinClientService';
+
+interface ResetPasswordProps {
+  token: string;
+  onBackToLogin: () => void;
+}
+
+export function ResetPassword({ token, onBackToLogin }: ResetPasswordProps) {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setTokenError('No reset token provided');
+    }
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    // Validation
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const client = getRayfinClient();
+      const result = await client.auth.completePasswordReset(token, password);
+
+      if (result.success) {
+        setSuccess(true);
+      } else {
+        setError(result.message || 'Failed to reset password');
+      }
+    } catch (err: any) {
+      console.error('Password reset error:', err);
+
+      // Handle specific error cases
+      if (err.message?.includes('expired')) {
+        setError('This reset link has expired. Please request a new one.');
+      } else if (err.message?.includes('used')) {
+        setError(
+          'This reset link has already been used. Please request a new one.'
+        );
+      } else if (err.message?.includes('invalid')) {
+        setError('Invalid reset link. Please request a new one.');
+      } else {
+        setError(err.message || 'Failed to reset password. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Show token error
+  if (tokenError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="max-w-md w-full p-8 bg-white rounded-lg shadow-md">
+          <div className="text-center mb-6">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 mb-4">
+              <svg
+                className="w-10 h-10 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Invalid Reset Link
+            </h2>
+            <p className="text-gray-600 mb-6">{tokenError}</p>
+          </div>
+          <button
+            onClick={onBackToLogin}
+            className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Back to Sign In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show success message
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="max-w-md w-full p-8 bg-white rounded-lg shadow-md">
+          <div className="text-center mb-6">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 mb-4">
+              <svg
+                className="w-10 h-10 text-green-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Password Reset Successfully
+            </h2>
+            <p className="text-gray-600 mb-6">
+              Your password has been updated. You can now sign in with your new
+              password.
+            </p>
+          </div>
+          <button
+            onClick={onBackToLogin}
+            className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Go to Sign In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show password reset form
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full p-8 bg-white rounded-lg shadow-md">
+        <h2 className="text-2xl font-bold mb-2 text-center">
+          Set New Password
+        </h2>
+        <p className="text-gray-600 mb-6 text-center text-sm">
+          Enter your new password below.
+        </p>
+
+        {error && (
+          <div className="p-3 mb-4 text-sm text-red-700 bg-red-100 rounded-lg">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label
+              htmlFor="password"
+              className="block text-gray-700 font-medium mb-2"
+            >
+              New Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="At least 6 characters"
+              required
+              disabled={loading}
+              minLength={6}
+            />
+          </div>
+
+          <div className="mb-6">
+            <label
+              htmlFor="confirmPassword"
+              className="block text-gray-700 font-medium mb-2"
+            >
+              Confirm New Password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Re-enter password"
+              required
+              disabled={loading}
+              minLength={6}
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 mb-3"
+          >
+            {loading ? 'Resetting Password...' : 'Reset Password'}
+          </button>
+
+          <button
+            type="button"
+            onClick={onBackToLogin}
+            className="w-full text-gray-600 hover:text-gray-800 text-sm"
+          >
+            Back to Sign In
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/SignupForm.tsx
+++ b/templates/todo-app/src/components/SignupForm.tsx
@@ -1,0 +1,349 @@
+import { useState, useEffect } from 'react';
+
+import { ServiceContainer } from '../services/ServiceContainer';
+
+import { ProfileImageUpload } from './ProfileImageUpload';
+
+const COOLDOWN_KEY = 'resendVerificationCooldown';
+const COOLDOWN_SECONDS = 30;
+
+interface SignupFormProps {
+  onToggleForm: () => void;
+}
+
+export function SignupForm({ onToggleForm }: SignupFormProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [emailVerificationRequired, setEmailVerificationRequired] =
+    useState(false);
+  const [loading, setLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [resendMessage, setResendMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  // Preview is handled inside the ProfileImageUpload; only keep pending file for deferred upload
+  const [_, setPendingFile] = useState<File | null>(null);
+
+  // Initialize cooldown from localStorage on mount
+  useEffect(() => {
+    const cooldownEnd = localStorage.getItem(COOLDOWN_KEY);
+    if (cooldownEnd) {
+      const remaining = Math.max(
+        0,
+        Math.floor((parseInt(cooldownEnd) - Date.now()) / 1000)
+      );
+      if (remaining > 0) {
+        setResendCooldown(remaining);
+      } else {
+        localStorage.removeItem(COOLDOWN_KEY);
+      }
+    }
+  }, []);
+
+  // Cooldown timer effect
+  useEffect(() => {
+    if (resendCooldown > 0) {
+      const timer = setTimeout(() => {
+        const newCooldown = resendCooldown - 1;
+        setResendCooldown(newCooldown);
+        if (newCooldown === 0) {
+          localStorage.removeItem(COOLDOWN_KEY);
+        }
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [resendCooldown]);
+
+  // TODO: In future iterations, profileImageUrl will be passed to the auth service
+  // to associate the uploaded image with the new user account
+
+  const handleResendVerification = async () => {
+    if (resendCooldown > 0) {
+      setResendMessage({
+        type: 'error',
+        text: `Please wait ${resendCooldown} seconds before resending.`,
+      });
+      return;
+    }
+
+    setResendMessage(null);
+    setResendLoading(true);
+
+    try {
+      const result =
+        await ServiceContainer.create().authService.resendVerificationEmail(
+          email
+        );
+      setResendMessage({ type: 'success', text: result.message });
+      const cooldownEnd = Date.now() + COOLDOWN_SECONDS * 1000;
+      localStorage.setItem(COOLDOWN_KEY, cooldownEnd.toString());
+      setResendCooldown(COOLDOWN_SECONDS);
+    } catch (err) {
+      console.error('Resend verification error:', err);
+      setResendMessage({
+        type: 'error',
+        text:
+          err instanceof Error
+            ? err.message
+            : 'Failed to resend verification email',
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    // Basic validation
+    if (!email || !password) {
+      setError('Email and password are required');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      // Use auth service from ServiceContainer to support both mock and rayfin modes
+      const authService = ServiceContainer.create().authService;
+
+      // Sign up the user
+      const result = await authService.signUp(email, password);
+      setSuccess(true);
+
+      // Check if email verification is required
+      setEmailVerificationRequired(!result.emailVerified);
+
+      // Profile image upload is deferred until after first login
+      setPendingFile(null);
+    } catch (err) {
+      console.error('Signup error:', err);
+      setError(err instanceof Error ? err.message : 'Signup failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Show success message after signup
+  if (success) {
+    // If email verification is not required, show simple success message
+    if (!emailVerificationRequired) {
+      return (
+        <div className="p-6 bg-white rounded-lg shadow-md">
+          <div className="text-center mb-6">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 mb-4">
+              <svg
+                className="w-10 h-10 text-green-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Account Created Successfully!
+            </h2>
+            <p className="text-gray-600 mb-4">
+              Your account has been created for:
+            </p>
+            <p className="text-lg font-medium text-gray-900 mb-4">{email}</p>
+            <p className="text-sm text-gray-600">
+              You can now sign in with your credentials.
+            </p>
+          </div>
+
+          <button
+            onClick={onToggleForm}
+            className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Go to Sign In
+          </button>
+        </div>
+      );
+    }
+
+    // Email verification required - show verification instructions
+    return (
+      <div className="p-6 bg-white rounded-lg shadow-md">
+        <div className="text-center mb-6">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 mb-4">
+            <svg
+              className="w-10 h-10 text-green-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Account Created!
+          </h2>
+          <p className="text-gray-600 mb-4">
+            We've sent a verification email to:
+          </p>
+          <p className="text-lg font-medium text-gray-900 mb-4">{email}</p>
+          <p className="text-sm text-gray-600">
+            Please check your inbox and click the verification link to activate
+            your account before signing in.
+          </p>
+        </div>
+
+        {resendMessage && (
+          <div
+            className={`p-3 mb-4 text-sm rounded-lg ${
+              resendMessage.type === 'success'
+                ? 'text-green-700 bg-green-100'
+                : 'text-red-700 bg-red-100'
+            }`}
+          >
+            {resendMessage.text}
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <button
+            onClick={handleResendVerification}
+            disabled={resendLoading || resendCooldown > 0}
+            className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {resendLoading
+              ? 'Resending...'
+              : resendCooldown > 0
+                ? `Resend in ${resendCooldown}s`
+                : 'Resend Verification Email'}
+          </button>
+          <button
+            onClick={onToggleForm}
+            className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Back to Sign In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 bg-white rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold mb-6 text-center">Create Account</h2>
+
+      {error && (
+        <div className="p-3 mb-4 text-sm text-red-700 bg-red-100 rounded-lg">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        {/* Profile Image Upload */}
+        <div className="mb-6">
+          <label className="block text-gray-700 font-medium mb-2">
+            Profile Image (Optional)
+          </label>
+          <ProfileImageUpload
+            onImageSelected={(file) => {
+              setPendingFile(file);
+            }}
+            className="bg-gray-50 p-4 rounded-lg"
+          />
+        </div>
+        <div className="mb-4">
+          <label
+            htmlFor="email"
+            className="block text-gray-700 font-medium mb-2"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
+        <div className="mb-4">
+          <label
+            htmlFor="password"
+            className="block text-gray-700 font-medium mb-2"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
+        <div className="mb-6">
+          <label
+            htmlFor="confirmPassword"
+            className="block text-gray-700 font-medium mb-2"
+          >
+            Confirm Password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50"
+        >
+          {loading ? 'Creating Account...' : 'Sign Up'}
+        </button>
+      </form>
+
+      <div className="mt-4 text-center">
+        <button
+          onClick={onToggleForm}
+          className="text-blue-500 hover:text-blue-700"
+        >
+          Already have an account? Sign in
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/TodoForm.tsx
+++ b/templates/todo-app/src/components/TodoForm.tsx
@@ -1,0 +1,251 @@
+import { getFieldConstraints, toStandardSchema } from '@microsoft/rayfin-core';
+import { useMemo, useState } from 'react';
+
+import { Category } from '../../rayfin/data/Category';
+import { Todo } from '../../rayfin/data/Todo';
+import { useAuth } from '../hooks/useAuth';
+import { useCategories } from '../hooks/useCategories';
+
+import { CategoryManager } from './CategoryManager';
+
+interface TodoFormProps {
+  onSubmit: (
+    todo: Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>
+  ) => Promise<Todo>;
+  onCancel: () => void;
+  onCategoryDeleted?: (categoryId: string) => void;
+  onCategoryChanged?: () => void; // Notify parent when categories change
+}
+
+export function TodoForm({
+  onSubmit,
+  onCancel,
+  onCategoryDeleted,
+  onCategoryChanged,
+}: TodoFormProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<'low' | 'medium' | 'high'>('medium');
+  const [dueDate, setDueDate] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<
+    Category | undefined
+  >();
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const { user } = useAuth();
+  const { categories, createCategory, updateCategory, deleteCategory } =
+    useCategories();
+
+  // Build a Standard Schema validator from the @entity()-decorated Todo.
+  // We omit the fields the service owns (id + timestamps) so the validated
+  // value lines up with the createTodo signature exactly.
+  const todoInputSchema = useMemo(
+    () =>
+      toStandardSchema(Todo, {
+        omit: ['createdAt', 'updatedAt'] as const,
+      }),
+    []
+  );
+
+  const titleConstraints = getFieldConstraints(Todo, 'Title');
+  const titleMaxLength =
+    titleConstraints?.type === 'string' ? titleConstraints.max : undefined;
+
+  const handleCategoryCreate = async (category: {
+    name: string;
+    color?: string;
+  }): Promise<Category> => {
+    if (!user)
+      throw new Error('User must be authenticated to create categories');
+
+    const categoryData: Omit<Category, 'id' | 'Id'> = {
+      name: category.name,
+      color: category.color || '#3B82F6', // Default color
+      user_id: user.Id,
+    };
+
+    const newCategory = await createCategory(categoryData);
+    onCategoryChanged?.(); // Notify parent that categories changed
+    return newCategory;
+  };
+
+  const handleCategoryUpdate = async (
+    id: string,
+    updates: { name?: string; color?: string }
+  ): Promise<Category> => {
+    const updatedCategory = await updateCategory(id, updates);
+    onCategoryChanged?.(); // Notify parent that categories changed
+    return updatedCategory;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) throw new Error('User must be authenticated to create todos');
+
+    const candidate = {
+      Title: title.trim(),
+      description: description.trim() || undefined,
+      isCompleted: false,
+      priority,
+      dueDate: dueDate ? new Date(dueDate) : undefined,
+      user_id: user.Id,
+      category: selectedCategory,
+      percentComplete: 0,
+    };
+
+    const result = todoInputSchema.validate(candidate);
+    if (result.issues) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of result.issues) {
+        const key = String(issue.path?.[0] ?? '_');
+        if (!fieldErrors[key]) fieldErrors[key] = issue.message;
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+    setErrors({});
+
+    setLoading(true);
+    try {
+      await onSubmit(result.value);
+
+      // Reset form
+      setTitle('');
+      setDescription('');
+      setPriority('medium');
+      setDueDate('');
+      setSelectedCategory(undefined);
+      onCancel();
+    } catch (err) {
+      // Error handled by parent
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCategoryDelete = async (categoryId: string) => {
+    await deleteCategory(categoryId);
+    // Notify parent component about the deletion so it can clean up todos
+    onCategoryDeleted?.(categoryId);
+    onCategoryChanged?.(); // Notify parent that categories changed
+
+    // Clear selected category if it was the deleted one
+    if (selectedCategory?.id === categoryId) {
+      setSelectedCategory(undefined);
+    }
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow border">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">Add New Todo</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="title"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Title *
+            {titleMaxLength !== undefined && (
+              <span className="ml-2 text-xs text-gray-500">
+                ({title.length}/{titleMaxLength})
+              </span>
+            )}
+          </label>
+          <input
+            id="title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          />
+          {errors.Title && (
+            <p className="mt-1 text-sm text-red-600">{errors.Title}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="description"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Description
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="priority"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Priority
+          </label>
+          <select
+            id="priority"
+            value={priority}
+            onChange={(e) =>
+              setPriority(e.target.value as 'low' | 'medium' | 'high')
+            }
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </select>
+        </div>
+
+        <div>
+          <CategoryManager
+            categories={categories}
+            selectedCategory={selectedCategory}
+            onCategorySelect={setSelectedCategory}
+            onCategoryCreate={handleCategoryCreate}
+            onCategoryUpdate={handleCategoryUpdate}
+            onCategoryDelete={handleCategoryDelete}
+            disabled={loading}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="dueDate"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Due Date
+          </label>
+          <input
+            id="dueDate"
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        <div className="flex space-x-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex-1 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            {loading ? 'Adding...' : 'Add Todo'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/TodoItem.tsx
+++ b/templates/todo-app/src/components/TodoItem.tsx
@@ -1,0 +1,74 @@
+import { Todo } from '../../rayfin/data/Todo';
+
+import { CategoryBadge } from './CategoryBadge';
+
+interface TodoItemProps {
+  todo: Todo;
+  onUpdate: (
+    id: string,
+    updates: Partial<Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>>
+  ) => Promise<Todo>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+export function TodoItem({ todo, onUpdate, onDelete }: TodoItemProps) {
+  const handleToggleComplete = () => {
+    onUpdate(todo.id, { isCompleted: !todo.isCompleted });
+  };
+
+  const handleDelete = () => {
+    onDelete(todo.id);
+  };
+
+  const priorityColors = {
+    low: 'bg-green-100 text-green-800',
+    medium: 'bg-yellow-100 text-yellow-800',
+    high: 'bg-red-100 text-red-800',
+  };
+
+  return (
+    <div className="flex items-center space-x-3 p-4 bg-white rounded-lg shadow border">
+      <input
+        type="checkbox"
+        checked={todo.isCompleted}
+        onChange={handleToggleComplete}
+        className="h-4 w-4"
+      />
+      <div className="flex-1 min-w-0">
+        <div
+          className={`text-sm font-medium ${todo.isCompleted ? 'text-gray-500 line-through' : 'text-gray-900'}`}
+        >
+          {todo.Title}
+        </div>
+        {todo.description && (
+          <div
+            className={`text-sm ${todo.isCompleted ? 'text-gray-400' : 'text-gray-600'}`}
+          >
+            {todo.description}
+          </div>
+        )}
+        <div className="flex items-center space-x-2 mt-1">
+          <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${priorityColors[todo.priority]}`}
+          >
+            {todo.priority}
+          </span>
+          {todo.category && (
+            <CategoryBadge category={todo.category} size="sm" />
+          )}
+          {todo.dueDate && (
+            <span className="text-xs text-gray-500">
+              Due: {new Date(todo.dueDate).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+      </div>
+      <button
+        onClick={handleDelete}
+        className="bg-transparent border-0 text-red-600 hover:text-red-800 text-sm font-medium px-2 py-1 rounded hover:bg-red-50 transition-colors"
+      >
+        Delete
+      </button>
+    </div>
+  );
+}

--- a/templates/todo-app/src/components/TodoList.tsx
+++ b/templates/todo-app/src/components/TodoList.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+
+import { useCategories } from '../hooks/useCategories';
+import { useTodos, TodoFilters } from '../hooks/useTodos';
+
+import { CategoryFilter } from './CategoryFilter';
+import { TodoForm } from './TodoForm';
+import { TodoItem } from './TodoItem';
+
+export function TodoList() {
+  const [showForm, setShowForm] = useState(false);
+  const [filters, setFilters] = useState<TodoFilters>({
+    categoryIds: [],
+    includeUncategorized: false,
+  });
+
+  const {
+    todos,
+    allTodos,
+    loading,
+    error,
+    createTodo,
+    updateTodo,
+    deleteTodo,
+    removeCategoryFromTodos,
+  } = useTodos(filters);
+  const { categories, refreshCategories } = useCategories();
+
+  // Handle cleanup when a category is deleted (called by TodoForm)
+  const handleCategoryDeleted = async (categoryId: string) => {
+    await removeCategoryFromTodos(categoryId);
+
+    // Remove deleted category from active filters
+    setFilters((prev) => ({
+      ...prev,
+      categoryIds: prev.categoryIds.filter((id) => id !== categoryId),
+    }));
+  };
+
+  // Handle category changes (created, updated, deleted) - refresh category list
+  const handleCategoryChanged = () => {
+    refreshCategories();
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <div className="text-gray-500">Loading todos...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+        Error: {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold text-gray-900">My Todos</h2>
+        <button
+          onClick={() => setShowForm(true)}
+          className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          Add Todo
+        </button>
+      </div>
+
+      {showForm && (
+        <TodoForm
+          onSubmit={createTodo}
+          onCancel={() => setShowForm(false)}
+          onCategoryDeleted={handleCategoryDeleted}
+          onCategoryChanged={handleCategoryChanged}
+        />
+      )}
+
+      <CategoryFilter
+        categories={categories}
+        allTodos={allTodos}
+        filters={filters}
+        onFiltersChange={setFilters}
+      />
+
+      {todos.length === 0 ? (
+        <div className="text-center py-12">
+          <div className="text-gray-500 text-lg">No todos yet</div>
+          <div className="text-gray-400 text-sm mt-2">
+            Click "Add Todo" to create your first task
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {todos.map((todo) => (
+            <TodoItem
+              key={todo.id}
+              todo={todo}
+              onUpdate={updateTodo}
+              onDelete={deleteTodo}
+            />
+          ))}
+        </div>
+      )}
+
+      {todos.length > 0 && (
+        <div className="text-center text-sm text-gray-500 pt-4">
+          {todos.filter((t) => !t.isCompleted).length} of {todos.length} todos
+          remaining
+        </div>
+      )}
+    </div>
+  );
+}

--- a/templates/todo-app/src/hooks/AuthContext.tsx
+++ b/templates/todo-app/src/hooks/AuthContext.tsx
@@ -1,0 +1,177 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+} from 'react';
+
+import { AuthStateObserver } from '../components/AuthStateObserver';
+import { AuthUser } from '../models/AuthUser';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+interface AuthContextType {
+  user: AuthUser | null;
+  loading: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<AuthUser>;
+  logout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
+  isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const authService = ServiceContainer.create().authService;
+
+  // Check authentication state on mount
+  useEffect(() => {
+    console.log('AuthProvider: Initial auth check...');
+    authService
+      .getCurrentUser()
+      .then((currentUser) => {
+        console.log('AuthProvider: Current user from storage:', currentUser);
+        if (currentUser) {
+          setUser(currentUser);
+          return;
+        }
+
+        // No existing session — try embedded auto-login (no-op if not embedded)
+        return authService.initEmbeddedAuth().then((embeddedUser) => {
+          if (embeddedUser) {
+            console.log('AuthProvider: Embedded auto-login succeeded');
+          }
+          setUser(embeddedUser);
+        });
+      })
+      .catch((err) => {
+        console.log('AuthProvider: Auth init failed:', err);
+        setUser(null);
+      })
+      .finally(() => setLoading(false));
+  }, [authService]);
+
+  // Log user state changes
+  useEffect(() => {
+    console.log('AuthProvider: User state changed to:', user);
+  }, [user]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      console.log('AuthProvider: Starting login...');
+      setError(null);
+      setLoading(true);
+
+      try {
+        const loggedInUser = await authService.login(email, password);
+        console.log('AuthProvider: Login successful! User:', loggedInUser);
+
+        setUser(loggedInUser);
+        setLoading(false);
+
+        console.log('AuthProvider: State updated');
+        return loggedInUser;
+      } catch (err) {
+        console.error('AuthProvider: Login failed:', err);
+        const message = err instanceof Error ? err.message : 'Login failed';
+        setError(message);
+        setLoading(false);
+        throw err;
+      }
+    },
+    [authService]
+  );
+
+  const logout = useCallback(async () => {
+    console.log('AuthProvider: Logging out...');
+    try {
+      await authService.logout();
+      setUser(null);
+      setError(null);
+    } catch (err) {
+      console.error('AuthProvider: Logout error:', err);
+    }
+  }, [authService]);
+
+  const refreshUser = useCallback(async () => {
+    console.log('AuthProvider: Refreshing user...');
+    try {
+      const currentUser = await authService.getCurrentUser();
+      console.log('AuthProvider: Refreshed user:', currentUser);
+      setUser(currentUser);
+    } catch (err) {
+      console.error('AuthProvider: Refresh user error:', err);
+      setUser(null);
+    }
+  }, [authService]);
+
+  const contextValue: AuthContextType = {
+    user,
+    loading,
+    error,
+    login,
+    logout,
+    refreshUser,
+    isAuthenticated: !!user,
+  };
+
+  console.log(
+    'AuthProvider: Rendering with user:',
+    !!user,
+    'loading:',
+    loading
+  );
+
+  const handleAuthStateChange = useCallback(
+    (isAuthenticated: boolean) => {
+      if (!isAuthenticated && user) {
+        // User has been logged out
+        setUser(null);
+      } else if (isAuthenticated && !user) {
+        // User has been logged in, but we need to fetch the details
+        authService
+          .getCurrentUser()
+          .then((currentUser) => {
+            if (currentUser) {
+              setUser(currentUser);
+            }
+          })
+          .catch((err) => {
+            console.error('Error getting current user:', err);
+          });
+      }
+    },
+    [user, authService]
+  );
+
+  return (
+    <AuthContext.Provider value={contextValue}>
+      <AuthStateObserver onAuthStateChange={handleAuthStateChange} />
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  console.log(
+    'useAuth: Hook called, returning user:',
+    !!context.user,
+    'loading:',
+    context.loading
+  );
+  return context;
+}

--- a/templates/todo-app/src/hooks/AuthSettingsContext.tsx
+++ b/templates/todo-app/src/hooks/AuthSettingsContext.tsx
@@ -1,0 +1,135 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+  useMemo,
+} from 'react';
+
+/**
+ * Available authentication methods.
+ * Matches the AuthMethod type from \@microsoft/rayfin-auth.
+ */
+export type AuthMethod = 'password' | 'magiclink' | 'fabric';
+
+/**
+ * Authentication settings configuration returned by the backend.
+ * Matches the AuthSettingsConfig type from \@microsoft/rayfin-auth.
+ */
+export interface AuthSettingsConfig {
+  enabled: boolean;
+  password: { enabled: boolean };
+  passwordless: { magicLink: { enabled: boolean } };
+  fabric?: { enabled: boolean };
+  availableMethods: AuthMethod[];
+}
+
+/**
+ * Auth settings state for the context
+ */
+interface AuthSettingsState {
+  /** Whether auth settings have been loaded */
+  loading: boolean;
+  /** Auth settings from the backend (null if not loaded or in mock mode) */
+  settings: AuthSettingsConfig | null;
+  /** Error message if fetching settings failed */
+  error: string | null;
+}
+
+/**
+ * Auth settings context value including computed helpers
+ */
+interface AuthSettingsContextValue extends AuthSettingsState {
+  /** Whether password authentication is available */
+  isPasswordAuthAvailable: boolean;
+  /** Whether magic link authentication is available */
+  isMagicLinkAuthAvailable: boolean;
+  /** Whether Fabric brokered authentication is available */
+  isFabricAuthAvailable: boolean;
+  /** List of available authentication methods */
+  availableMethods: AuthMethod[];
+}
+
+const AuthSettingsContext = createContext<AuthSettingsContextValue | undefined>(
+  undefined
+);
+
+interface AuthSettingsProviderProps {
+  children: ReactNode;
+}
+
+/** Default auth settings - all methods enabled */
+const DEFAULT_AUTH_SETTINGS: AuthSettingsConfig = {
+  enabled: true,
+  password: { enabled: true },
+  passwordless: { magicLink: { enabled: true } },
+  fabric: { enabled: true },
+  availableMethods: ['password', 'magiclink', 'fabric'],
+};
+
+/** Provides auth settings to the component tree. */
+export function AuthSettingsProvider({ children }: AuthSettingsProviderProps) {
+  const [state, setState] = useState<AuthSettingsState>({
+    loading: true,
+    settings: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    setState({
+      loading: false,
+      settings: DEFAULT_AUTH_SETTINGS,
+      error: null,
+    });
+  }, []);
+
+  // Compute derived values
+  const contextValue = useMemo<AuthSettingsContextValue>(() => {
+    const settings = state.settings || DEFAULT_AUTH_SETTINGS;
+    return {
+      ...state,
+      isPasswordAuthAvailable: settings.password.enabled,
+      isMagicLinkAuthAvailable: settings.passwordless.magicLink.enabled,
+      isFabricAuthAvailable: settings.fabric?.enabled ?? false,
+      availableMethods: settings.availableMethods,
+    };
+  }, [state]);
+
+  return (
+    <AuthSettingsContext.Provider value={contextValue}>
+      {children}
+    </AuthSettingsContext.Provider>
+  );
+}
+
+/**
+ * Hook to access auth settings from the context.
+ *
+ * @example
+ * ```tsx
+ * function AuthPage() {
+ *   const { isPasswordAuthAvailable, isMagicLinkAuthAvailable, loading } = useAuthSettings();
+ *
+ *   if (loading) {
+ *     return <LoadingSpinner />;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       {isPasswordAuthAvailable && <LoginForm />}
+ *       {isMagicLinkAuthAvailable && <MagicLinkForm />}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useAuthSettings(): AuthSettingsContextValue {
+  const context = useContext(AuthSettingsContext);
+  if (context === undefined) {
+    throw new Error(
+      'useAuthSettings must be used within an AuthSettingsProvider'
+    );
+  }
+  return context;
+}

--- a/templates/todo-app/src/hooks/useAuth.ts
+++ b/templates/todo-app/src/hooks/useAuth.ts
@@ -1,0 +1,93 @@
+import { useState, useEffect, useCallback } from 'react';
+
+import { AuthUser } from '../models/AuthUser';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+export function useAuth() {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [forceRender, setForceRender] = useState(0);
+
+  const authService = ServiceContainer.create().authService;
+
+  // Function to check current auth state
+  const checkAuthState = useCallback(async () => {
+    try {
+      const currentUser = await authService.getCurrentUser();
+      console.log('useAuth: Current user from storage:', currentUser);
+      setUser(currentUser);
+      return currentUser;
+    } catch {
+      console.log('useAuth: No current user found');
+      setUser(null);
+      return null;
+    }
+  }, [authService]);
+
+  // Check authentication state on mount and when forceRender changes
+  useEffect(() => {
+    console.log('useAuth: Checking authentication state...');
+    checkAuthState().finally(() => setLoading(false));
+  }, [checkAuthState, forceRender]);
+
+  // Log user state changes
+  useEffect(() => {
+    console.log('useAuth: User state changed to:', user);
+  }, [user]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      console.log('useAuth: Starting login...');
+      setError(null);
+      setLoading(true);
+
+      try {
+        const loggedInUser = await authService.login(email, password);
+        console.log('useAuth: Login successful! User:', loggedInUser);
+
+        // Force React to treat this as a new state by using functional update
+        setUser((prevUser) => {
+          console.log(
+            'useAuth: Setting user via functional update from:',
+            prevUser,
+            'to:',
+            loggedInUser
+          );
+          return { ...loggedInUser };
+        });
+
+        setLoading(false);
+
+        // Force a re-render
+        setForceRender((prev) => prev + 1);
+
+        console.log('useAuth: State updated with user copy');
+        return loggedInUser;
+      } catch (err) {
+        console.error('useAuth: Login failed:', err);
+        const message = err instanceof Error ? err.message : 'Login failed';
+        setError(message);
+        setLoading(false);
+        throw err;
+      }
+    },
+    [authService]
+  );
+
+  const logout = useCallback(async () => {
+    console.log('useAuth: Logging out...');
+    try {
+      await authService.logout();
+      setUser(null);
+      setError(null);
+      setForceRender((prev) => prev + 1);
+    } catch (err) {
+      console.error('Logout error:', err);
+    }
+  }, [authService]);
+
+  console.log('useAuth: Current state - user:', !!user, 'loading:', loading);
+
+  return { user, loading, error, login, logout, isAuthenticated: !!user };
+}

--- a/templates/todo-app/src/hooks/useCategories.ts
+++ b/templates/todo-app/src/hooks/useCategories.ts
@@ -1,0 +1,121 @@
+import { useState, useEffect, useCallback } from 'react';
+
+import { Category } from '../../rayfin/data/Category';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+import { useAuth } from './useAuth';
+
+interface UseCategoriesResult {
+  categories: Category[];
+  loading: boolean;
+  error: string | null;
+  createCategory: (category: Omit<Category, 'id' | 'Id'>) => Promise<Category>;
+  updateCategory: (
+    id: string,
+    updates: Partial<Omit<Category, 'id' | 'Id'>>
+  ) => Promise<Category>;
+  deleteCategory: (id: string) => Promise<void>;
+  refreshCategories: () => Promise<void>;
+}
+
+export function useCategories(): UseCategoriesResult {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { user, isAuthenticated } = useAuth();
+  const categoryService = ServiceContainer.create().categoryService;
+
+  const refreshCategories = useCallback(async () => {
+    if (!isAuthenticated || !user) {
+      setCategories([]);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setError(null);
+      const fetchedCategories = await categoryService.getCategories();
+      setCategories(fetchedCategories);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to load categories'
+      );
+      console.error('Error loading categories:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [isAuthenticated, user, categoryService]);
+
+  useEffect(() => {
+    refreshCategories();
+  }, [refreshCategories]);
+
+  const createCategory = useCallback(
+    async (category: Omit<Category, 'id' | 'Id'>): Promise<Category> => {
+      try {
+        setError(null);
+        const newCategory = await categoryService.createCategory(category);
+        setCategories((prev) => [...prev, newCategory]);
+        return newCategory;
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to create category';
+        setError(errorMessage);
+        throw err;
+      }
+    },
+    [categoryService]
+  );
+
+  const updateCategory = useCallback(
+    async (
+      id: string,
+      updates: Partial<Omit<Category, 'id'>>
+    ): Promise<Category> => {
+      try {
+        setError(null);
+        const updatedCategory = await categoryService.updateCategory(
+          id,
+          updates
+        );
+        setCategories((prev) =>
+          prev.map((cat) => (cat.id === id ? updatedCategory : cat))
+        );
+        return updatedCategory;
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to update category';
+        setError(errorMessage);
+        throw err;
+      }
+    },
+    [categoryService]
+  );
+
+  const deleteCategory = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        setError(null);
+        await categoryService.deleteCategory(id);
+        setCategories((prev) => prev.filter((cat) => cat.id !== id));
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to delete category';
+        setError(errorMessage);
+        throw err;
+      }
+    },
+    [categoryService]
+  );
+
+  return {
+    categories,
+    loading,
+    error,
+    createCategory,
+    updateCategory,
+    deleteCategory,
+    refreshCategories,
+  };
+}

--- a/templates/todo-app/src/hooks/useProfileImage.ts
+++ b/templates/todo-app/src/hooks/useProfileImage.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { ServiceContainer } from '../services/ServiceContainer';
+
+/**
+ * Hook for managing profile image operations
+ */
+export function useProfileImage(userId?: string) {
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const profileImageService = ServiceContainer.create().profileImageService;
+
+  const loadProfileImage = useCallback(
+    async (targetUserId: string) => {
+      try {
+        setError(null);
+        const imageUrl =
+          await profileImageService.getProfileImage(targetUserId);
+        setProfileImageUrl(imageUrl);
+      } catch (err) {
+        console.error('Failed to load profile image:', err);
+        setError(
+          err instanceof Error ? err.message : 'Failed to load profile image'
+        );
+        setProfileImageUrl(null);
+      }
+    },
+    [profileImageService]
+  );
+
+  // Load profile image on mount or when userId changes
+  useEffect(() => {
+    if (userId) {
+      loadProfileImage(userId);
+    } else {
+      setProfileImageUrl(null);
+    }
+  }, [userId]);
+
+  // Listen for global updates (e.g., after signup deferred upload) and refresh if it matches our userId
+  useEffect(() => {
+    const onUpdated = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { userId?: string }
+        | undefined;
+      if (detail?.userId && userId && detail.userId === userId) {
+        void loadProfileImage(userId);
+      }
+    };
+    window.addEventListener(
+      'profile-image-updated',
+      onUpdated as EventListener
+    );
+    return () =>
+      window.removeEventListener(
+        'profile-image-updated',
+        onUpdated as EventListener
+      );
+  }, [userId, loadProfileImage]);
+
+  const uploadProfileImage = useCallback(
+    async (targetUserId: string, file: File) => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // Validate the file first
+        const validation = profileImageService.validateImageFile(file);
+        if (!validation.isValid) {
+          throw new Error(validation.error);
+        }
+
+        // Upload the image
+        const imageUrl = await profileImageService.uploadProfileImage(
+          targetUserId,
+          file
+        );
+        setProfileImageUrl(imageUrl);
+
+        return imageUrl;
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to upload profile image';
+        setError(errorMessage);
+        throw new Error(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [profileImageService]
+  );
+
+  const getDisplayUrl = useCallback(() => {
+    return profileImageUrl || profileImageService.getDefaultAvatar();
+  }, [profileImageUrl, profileImageService]);
+
+  return {
+    profileImageUrl,
+    isLoading,
+    error,
+    uploadProfileImage,
+    getDisplayUrl,
+    refreshProfileImage: userId ? () => loadProfileImage(userId) : undefined,
+  };
+}

--- a/templates/todo-app/src/hooks/useTodos.ts
+++ b/templates/todo-app/src/hooks/useTodos.ts
@@ -1,0 +1,151 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+
+import { Todo } from '../../rayfin/data/Todo';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+import { useAuth } from './useAuth';
+
+export interface TodoFilters {
+  categoryIds: string[];
+  includeUncategorized: boolean;
+}
+
+export function useTodos(filters?: TodoFilters) {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { user, isAuthenticated } = useAuth();
+  const todoService = ServiceContainer.create().todoService;
+
+  const fetchTodos = useCallback(async () => {
+    if (!isAuthenticated || !user) {
+      setTodos([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await todoService.getTodos();
+      setTodos(data);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to fetch todos';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [isAuthenticated, user, todoService]);
+
+  useEffect(() => {
+    fetchTodos();
+  }, [fetchTodos]);
+
+  // Filter todos based on category filters
+  const filteredTodos = useMemo(() => {
+    if (
+      !filters ||
+      (filters.categoryIds.length === 0 && !filters.includeUncategorized)
+    ) {
+      return todos;
+    }
+
+    return todos.filter((todo) => {
+      // Check if todo has a category and if it's in the selected categories
+      if (todo.category && filters.categoryIds.includes(todo.category.id)) {
+        return true;
+      }
+
+      // Check if todo is uncategorized and we want to include uncategorized todos
+      if (!todo.category && filters.includeUncategorized) {
+        return true;
+      }
+
+      return false;
+    });
+  }, [todos, filters]);
+
+  const createTodo = useCallback(
+    async (todo: Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>) => {
+      try {
+        const newTodo = await todoService.createTodo(todo);
+        setTodos((prev) => [...prev, newTodo]);
+        return newTodo;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to create todo';
+        setError(message);
+        throw err;
+      }
+    },
+    [todoService]
+  );
+
+  const updateTodo = useCallback(
+    async (
+      id: string,
+      updates: Partial<Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>>
+    ) => {
+      try {
+        const updatedTodo = await todoService.updateTodo(id, updates);
+        setTodos((prev) =>
+          prev.map((todo) => (todo.id === id ? updatedTodo : todo))
+        );
+        return updatedTodo;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to update todo';
+        setError(message);
+        throw err;
+      }
+    },
+    [todoService]
+  );
+
+  const deleteTodo = useCallback(
+    async (id: string) => {
+      try {
+        await todoService.deleteTodo(id);
+        setTodos((prev) => prev.filter((todo) => todo.id !== id));
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to delete todo';
+        setError(message);
+        throw err;
+      }
+    },
+    [todoService]
+  );
+
+  // Function to remove category from todos when category is deleted
+  const removeCategoryFromTodos = useCallback(
+    async (categoryId: string) => {
+      const todosToUpdate = todos.filter(
+        (todo) => todo.category?.id === categoryId
+      );
+
+      for (const todo of todosToUpdate) {
+        try {
+          await updateTodo(todo.id, { category: undefined });
+        } catch (err) {
+          console.error('Failed to remove category from todo:', todo.id, err);
+        }
+      }
+    },
+    [todos, updateTodo]
+  );
+
+  return {
+    todos: filteredTodos,
+    allTodos: todos,
+    loading,
+    error,
+    createTodo,
+    updateTodo,
+    deleteTodo,
+    removeCategoryFromTodos,
+    refetch: fetchTodos,
+  };
+}

--- a/templates/todo-app/src/index.css
+++ b/templates/todo-app/src/index.css
@@ -1,0 +1,84 @@
+@import "tailwindcss";
+
+/* Form element resets for better Tailwind compatibility */
+button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+}
+
+input,
+textarea,
+select {
+  background: white;
+  color: #111827; /* text-gray-900 */
+  font: inherit;
+}
+
+/* Ensure date input calendar icon is visible */
+input[type='date'] {
+  background: white;
+  color: #111827; /* text-gray-900 */
+  color-scheme: light;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  opacity: 1;
+}
+
+input[type='date']::-webkit-inner-spin-button,
+input[type='date']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Force checkboxes to have proper light theme styling across all browsers */
+input[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: white;
+  border: 1px solid #d1d5db; /* border-gray-300 */
+  border-radius: 0.25rem; /* rounded */
+  width: 1rem; /* w-4 */
+  height: 1rem; /* h-4 */
+  position: relative;
+  cursor: pointer;
+}
+
+input[type='checkbox']:checked {
+  background: #2563eb; /* bg-blue-600 */
+  border-color: #2563eb;
+}
+
+input[type='checkbox']:checked::after {
+  content: '';
+  position: absolute;
+  left: 0.25rem;
+  top: 0.125rem;
+  width: 0.25rem;
+  height: 0.5rem;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+input[type='checkbox']:focus {
+  outline: 2px solid #3b82f6; /* focus:ring-blue-500 */
+  outline-offset: 2px;
+}
+
+/* Remove default button styles that conflict with Tailwind */
+button:hover {
+  border-color: initial;
+}
+
+button:focus,
+button:focus-visible {
+  outline: revert;
+}

--- a/templates/todo-app/src/main.tsx
+++ b/templates/todo-app/src/main.tsx
@@ -1,0 +1,37 @@
+import { bridgeFabricCallback } from '@microsoft/rayfin-auth-provider-fabric';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import './index.css';
+import App from './App';
+import { AuthProvider } from './hooks/AuthContext';
+import { AuthSettingsProvider } from './hooks/AuthSettingsContext';
+import { ServiceContainer } from './services/ServiceContainer';
+
+// Backward compat: old Fabric Portal may redirect the popup to the bare origin
+// (root page) with handoff params in the URL hash. Detect this early — before
+// mounting React — and bridge the handoff code to the opener tab. If the bridge
+// fires, the popup closes itself and there is nothing to render.
+if (bridgeFabricCallback()) {
+  // Popup is closing — skip the rest of the bootstrap.
+} else {
+  // Initialize the service container
+  // Service mode is determined by VITE_SERVICE_MODE environment variable
+  // Default: 'rayfin' - connects to the backend API
+  // Alternative: 'mock' - uses mock data for testing without a backend
+  const serviceMode =
+    (import.meta.env.VITE_SERVICE_MODE as 'mock' | 'rayfin') || 'rayfin';
+  console.log(`🚀 Initializing application in '${serviceMode}' mode`);
+
+  ServiceContainer.create(serviceMode);
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <AuthSettingsProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </AuthSettingsProvider>
+    </StrictMode>
+  );
+}

--- a/templates/todo-app/src/models/AuthUser.ts
+++ b/templates/todo-app/src/models/AuthUser.ts
@@ -1,0 +1,11 @@
+/**
+ * Frontend authentication user model
+ * This represents the user data needed for UI authentication state
+ * Separate from the database User entity used in relationships
+ */
+export interface AuthUser {
+  Id: string;
+  Email: string;
+  Name: string; // Display name for UI
+  profileImageUrl?: string; // Optional profile image URL or data URL
+}

--- a/templates/todo-app/src/pages/AuthCallback.tsx
+++ b/templates/todo-app/src/pages/AuthCallback.tsx
@@ -1,0 +1,24 @@
+import { bridgeFabricCallback } from '@microsoft/rayfin-auth-provider-fabric';
+
+import { MagicLinkCallback } from './MagicLinkCallback';
+
+/**
+ * Unified auth callback dispatcher for /auth/callback.
+ *
+ * With the postMessage-based Fabric auth flow, there is normally no Fabric
+ * redirect. However, old Fabric Portal deployments still redirect the popup
+ * here with handoff params. {@link bridgeFabricCallback} detects that case,
+ * forwards the handoff code to the opener via postMessage, and closes the
+ * popup — so {@link initiateFabricLogin}'s listener handles both paths.
+ *
+ * If no Fabric bridge was triggered, this page handles magic-link callbacks.
+ */
+export function AuthCallback() {
+  // Backward compat: old Fabric Portal redirects the popup here.
+  // Bridge the handoff code to the opener via postMessage and close.
+  if (bridgeFabricCallback()) {
+    return null;
+  }
+
+  return <MagicLinkCallback />;
+}

--- a/templates/todo-app/src/pages/Dashboard.tsx
+++ b/templates/todo-app/src/pages/Dashboard.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+import { ProfileImage } from '../components/ProfileImage';
+import { ProfileImageModal } from '../components/ProfileImageModal';
+import { TodoList } from '../components/TodoList';
+import { useAuth } from '../hooks/AuthContext';
+
+export function Dashboard() {
+  const { user, logout } = useAuth();
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <h1 className="text-xl font-semibold text-gray-900">Todo App</h1>
+            <div className="flex items-center space-x-4">
+              <div className="flex items-center space-x-3">
+                <ProfileImage
+                  userId={user.Id}
+                  size="sm"
+                  alt={`${user.Name}'s profile`}
+                  clickable={true}
+                  onClick={() => setIsProfileModalOpen(true)}
+                />
+                <span className="text-sm text-gray-600">
+                  Welcome, {user.Name}
+                </span>
+              </div>
+              <button
+                onClick={logout}
+                className="bg-transparent border-0 text-sm font-medium text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md hover:bg-gray-100 transition-colors"
+              >
+                Logout
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <TodoList />
+      </main>
+
+      <ProfileImageModal
+        userId={user.Id}
+        isOpen={isProfileModalOpen}
+        onClose={() => setIsProfileModalOpen(false)}
+      />
+    </div>
+  );
+}

--- a/templates/todo-app/src/pages/MagicLinkCallback.tsx
+++ b/templates/todo-app/src/pages/MagicLinkCallback.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuth } from '../hooks/AuthContext';
+import { ServiceContainer } from '../services/ServiceContainer';
+
+/**
+ * Handles the magic link callback after user clicks the link in their email.
+ * This page processes the authentication and redirects to the dashboard.
+ */
+export function MagicLinkCallback() {
+  const [error, setError] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(true);
+  const navigate = useNavigate();
+  const { refreshUser } = useAuth();
+  // Prevent double-execution in React StrictMode
+  const hasHandledCallback = useRef(false);
+
+  useEffect(() => {
+    // Guard against double-execution (React StrictMode mounts twice)
+    if (hasHandledCallback.current) {
+      return;
+    }
+    hasHandledCallback.current = true;
+
+    const handleCallback = async () => {
+      try {
+        const authService = ServiceContainer.create().authService;
+
+        // Verify this is actually a magic link callback
+        if (!authService.isMagicLinkCallback()) {
+          setError('Invalid callback URL. Please request a new magic link.');
+          setProcessing(false);
+          return;
+        }
+
+        // Handle the callback and authenticate
+        const result = await authService.handleMagicLinkCallback();
+
+        if (result.success && result.user) {
+          await refreshUser();
+          window.history.replaceState({}, document.title, '/');
+          navigate('/', { replace: true });
+        } else {
+          setError(result.error ?? 'Authentication failed. Please try again.');
+          setProcessing(false);
+        }
+      } catch (err) {
+        console.error('Magic link callback error:', err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Authentication failed. Please try again.'
+        );
+        setProcessing(false);
+      }
+    };
+
+    handleCallback();
+  }, [navigate, refreshUser]);
+
+  if (processing) {
+    return (
+      <div className="min-h-screen flex flex-col justify-center items-center bg-gray-50">
+        <div className="max-w-md w-full space-y-8 text-center">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mb-4">
+            <svg
+              className="w-8 h-8 text-blue-600 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900">
+            Signing you in...
+          </h2>
+          <p className="text-gray-600">
+            Please wait while we verify your magic link.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  return (
+    <div className="min-h-screen flex flex-col justify-center items-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8">
+        <div className="p-6 bg-white rounded-lg shadow-md text-center">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 mb-4">
+            <svg
+              className="w-10 h-10 text-red-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Sign in failed
+          </h2>
+          <p className="text-gray-600 mb-6">{error}</p>
+          <button
+            onClick={() => navigate('/', { replace: true })}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Back to sign in
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/pages/VerifyEmail.tsx
+++ b/templates/todo-app/src/pages/VerifyEmail.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, useRef } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+
+import { ServiceContainer } from '../services/ServiceContainer';
+
+type VerificationState = 'verifying' | 'success' | 'error' | 'expired';
+
+export function VerifyEmail() {
+  const [searchParams] = useSearchParams();
+  const [state, setState] = useState<VerificationState>('verifying');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const token = searchParams.get('token');
+  const verificationAttempted = useRef(false);
+
+  useEffect(() => {
+    const verifyEmail = async () => {
+      if (!token) {
+        setState('error');
+        setErrorMessage('Verification token is missing');
+        return;
+      }
+
+      // Prevent duplicate calls (React Strict Mode causes double render)
+      if (verificationAttempted.current) {
+        return;
+      }
+      verificationAttempted.current = true;
+
+      try {
+        const authService = ServiceContainer.create().authService;
+        await authService.verifyEmail(token);
+        setState('success');
+      } catch (error: any) {
+        console.error('Email verification failed:', error);
+
+        // Check if token is expired
+        if (
+          error.message?.includes('expired') ||
+          error.message?.includes('invalid')
+        ) {
+          setState('expired');
+          setErrorMessage(
+            error.message || 'Verification link has expired or is invalid'
+          );
+        } else {
+          setState('error');
+          setErrorMessage(
+            error.message || 'Failed to verify email. Please try again.'
+          );
+        }
+      }
+    };
+
+    verifyEmail();
+  }, [token]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-md p-8">
+        {state === 'verifying' && (
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto mb-4"></div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Verifying Email
+            </h2>
+            <p className="text-gray-600">
+              Please wait while we verify your email address...
+            </p>
+          </div>
+        )}
+
+        {state === 'success' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100 mb-4">
+              <svg
+                className="h-6 w-6 text-green-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Email Verified!
+            </h2>
+            <p className="text-gray-600 mb-6">
+              Your email has been successfully verified. You can now log in to
+              your account.
+            </p>
+            <Link
+              to="/login"
+              className="inline-block bg-indigo-600 text-white px-6 py-2 rounded-md hover:bg-indigo-700 transition-colors"
+            >
+              Go to Login
+            </Link>
+          </div>
+        )}
+
+        {state === 'expired' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-yellow-100 mb-4">
+              <svg
+                className="h-6 w-6 text-yellow-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Link Expired
+            </h2>
+            <p className="text-gray-600 mb-6">{errorMessage}</p>
+            <Link
+              to="/resend-verification"
+              className="inline-block bg-indigo-600 text-white px-6 py-2 rounded-md hover:bg-indigo-700 transition-colors"
+            >
+              Resend Verification Email
+            </Link>
+          </div>
+        )}
+
+        {state === 'error' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Verification Failed
+            </h2>
+            <p className="text-gray-600 mb-6">{errorMessage}</p>
+            <div className="space-y-3">
+              <Link
+                to="/resend-verification"
+                className="block bg-indigo-600 text-white px-6 py-2 rounded-md hover:bg-indigo-700 transition-colors"
+              >
+                Resend Verification Email
+              </Link>
+              <Link
+                to="/login"
+                className="block bg-gray-200 text-gray-700 px-6 py-2 rounded-md hover:bg-gray-300 transition-colors"
+              >
+                Back to Login
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/templates/todo-app/src/services/ServiceContainer.ts
+++ b/templates/todo-app/src/services/ServiceContainer.ts
@@ -1,0 +1,157 @@
+import { IAuthService } from './interfaces/IAuthService';
+import { ICategoryService } from './interfaces/ICategoryService';
+import { IProfileImageService } from './interfaces/IProfileImageService';
+import { IStorageService } from './interfaces/IStorageService';
+import { ITodoService } from './interfaces/ITodoService';
+import { LocalStorageService } from './mock/LocalStorageService';
+import { MockAuthService } from './mock/MockAuthService';
+import { MockCategoryService } from './mock/MockCategoryService';
+import { MockProfileImageService } from './mock/MockProfileImageService';
+import { MockTodoService } from './mock/MockTodoService';
+import { RayfinAuthService } from './rayfin/RayfinAuthService';
+import { RayfinCategoryService } from './rayfin/RayfinCategoryService';
+import { RayfinClientService } from './rayfin/RayfinClientService';
+import { RayfinProfileImageService } from './rayfin/RayfinProfileImageService';
+import { RayfinTodoService } from './rayfin/RayfinTodoService';
+
+export class ServiceContainer {
+  private static instance: ServiceContainer | null = null;
+
+  private constructor(
+    public readonly storageService: IStorageService,
+    public readonly authService: IAuthService,
+    public readonly todoService: ITodoService,
+    public readonly categoryService: ICategoryService,
+    public readonly profileImageService: IProfileImageService
+  ) {}
+
+  /**
+   * Get the RayfinClient instance if in Rayfin mode
+   */
+  public get rayfinClient():
+    | ReturnType<
+        ReturnType<typeof RayfinClientService.getInstance>['getClient']
+      >
+    | undefined {
+    try {
+      return RayfinClientService.getInstance().isInitialized()
+        ? RayfinClientService.getInstance().getClient()
+        : undefined;
+    } catch (error) {
+      return undefined;
+    }
+  }
+
+  static create(mode: 'mock' | 'rayfin' = 'mock'): ServiceContainer {
+    if (!ServiceContainer.instance) {
+      if (mode === 'mock') {
+        console.log('Creating ServiceContainer with mock services');
+        const storage = new LocalStorageService();
+        const auth = new MockAuthService(storage);
+        ServiceContainer.instance = new ServiceContainer(
+          storage,
+          auth,
+          new MockTodoService(storage, auth),
+          new MockCategoryService(storage, auth),
+          new MockProfileImageService(storage)
+        );
+      } else {
+        try {
+          // Rayfin implementation
+          const storage = new LocalStorageService();
+
+          // Get API URL from environment variables with fallback
+          const apiUrl =
+            import.meta.env.VITE_RAYFIN_API_URL || 'http://localhost:5168';
+          console.log('🔧 Initializing Rayfin services with API URL:', apiUrl);
+
+          // Get publishable key from environment variables
+          const publishableKey = import.meta.env.VITE_RAYFIN_PUBLISHABLE_KEY;
+          if (!publishableKey) {
+            throw new Error(
+              'VITE_RAYFIN_PUBLISHABLE_KEY environment variable is required for Rayfin mode'
+            );
+          }
+
+          // Initialize the Rayfin client through the singleton service
+          const rayfinClientService = RayfinClientService.getInstance();
+          rayfinClientService.initialize(
+            apiUrl.endsWith('/') ? apiUrl : `${apiUrl}/`,
+            publishableKey
+          );
+
+          const authService = new RayfinAuthService();
+
+          // Create the Rayfin service container with full @microsoft/rayfin-data integration
+          ServiceContainer.instance = new ServiceContainer(
+            storage, // Still use localStorage for local app state
+            authService, // RayfinAuthService for authentication
+            new RayfinTodoService(), // Now uses @microsoft/rayfin-data DataApi for real database operations
+            new RayfinCategoryService(), // RayfinCategoryService for category operations
+            new RayfinProfileImageService() // RayfinProfileImageService for profile image storage
+          );
+
+          console.log('✅ Rayfin services initialized successfully');
+
+          // Add a safety check and fallback for CORS or connection issues
+          window.addEventListener('unhandledrejection', (event) => {
+            // If we get an unhandled rejection that could be related to CORS
+            if (
+              event.reason &&
+              (event.reason.toString().includes('CORS') ||
+                event.reason.toString().includes('NetworkError') ||
+                event.reason.toString().includes('Failed to fetch'))
+            ) {
+              console.warn(
+                'Detected CORS or network error, falling back to mock mode'
+              );
+              console.warn('Error details:', event.reason);
+
+              // Only fall back if we're still using Rayfin mode
+              if (ServiceContainer.instance?.rayfinClient) {
+                // Reset the client service
+                RayfinClientService.getInstance().reset();
+                ServiceContainer.reset();
+                ServiceContainer.create('mock');
+
+                // Notify the user that we've fallen back to mock mode
+                alert(
+                  'Unable to connect to the backend service. Falling back to mock mode.'
+                );
+
+                // Reload the page to ensure clean state
+                window.location.reload();
+              }
+            }
+          });
+        } catch (error) {
+          console.error('❌ Failed to initialize Rayfin services:', error);
+          console.warn('Falling back to mock mode due to initialization error');
+
+          // Fall back to mock mode
+          const storage = new LocalStorageService();
+          const auth = new MockAuthService(storage);
+          ServiceContainer.instance = new ServiceContainer(
+            storage,
+            auth,
+            new MockTodoService(storage, auth),
+            new MockCategoryService(storage, auth),
+            new MockProfileImageService(storage)
+          );
+
+          // Show user-friendly error message
+          setTimeout(() => {
+            alert(
+              'Unable to connect to the backend service. Running in offline mode with mock data.'
+            );
+          }, 100);
+        }
+      }
+    }
+    return ServiceContainer.instance;
+  }
+
+  static reset(): void {
+    ServiceContainer.instance = null;
+  }
+}

--- a/templates/todo-app/src/services/interfaces/IAuthService.ts
+++ b/templates/todo-app/src/services/interfaces/IAuthService.ts
@@ -1,0 +1,48 @@
+import { AuthUser } from '../../models/AuthUser';
+
+export interface SignUpResult {
+  emailVerified: boolean;
+}
+
+export interface MagicLinkSendResult {
+  success: boolean;
+  state: string;
+  message?: string;
+}
+
+export interface MagicLinkCallbackResult {
+  success: boolean;
+  user?: AuthUser;
+  error?: string;
+}
+
+export interface IAuthService {
+  signUp(email: string, password: string): Promise<SignUpResult>;
+  login(email: string, password: string): Promise<AuthUser>;
+  logout(): Promise<void>;
+  getCurrentUser(): Promise<AuthUser | null>;
+  isAuthenticated(): Promise<boolean>;
+  verifyEmail(token: string): Promise<void>;
+  resendVerificationEmail(
+    email: string
+  ): Promise<{ success: boolean; message: string }>;
+
+  // Magic link / passwordless authentication
+  sendMagicLink(
+    email: string,
+    redirectUri: string
+  ): Promise<MagicLinkSendResult>;
+  handleMagicLinkCallback(): Promise<MagicLinkCallbackResult>;
+  isMagicLinkCallback(): boolean;
+
+  // Fabric brokered authentication
+  initiateFabricLogin(): Promise<void>;
+  ensureSignedInWithFabric(): Promise<AuthUser>;
+  /**
+   * Auto-detects embedded mode (`?fabricEmbedded=true`) and silently
+   * authenticates via the host's postMessage bridge. Returns the
+   * authenticated user, or `null` if not in embedded mode.
+   * Safe to call on page load — never opens a popup.
+   */
+  initEmbeddedAuth(): Promise<AuthUser | null>;
+}

--- a/templates/todo-app/src/services/interfaces/ICategoryService.ts
+++ b/templates/todo-app/src/services/interfaces/ICategoryService.ts
@@ -1,0 +1,12 @@
+import { Category } from '../../../rayfin/data/Category';
+
+export interface ICategoryService {
+  getCategories(): Promise<Category[]>;
+  getCategoryById(id: string): Promise<Category | null>;
+  createCategory(category: Omit<Category, 'id' | 'Id'>): Promise<Category>;
+  updateCategory(
+    id: string,
+    updates: Partial<Omit<Category, 'id' | 'Id'>>
+  ): Promise<Category>;
+  deleteCategory(id: string): Promise<void>;
+}

--- a/templates/todo-app/src/services/interfaces/IProfileImageService.ts
+++ b/templates/todo-app/src/services/interfaces/IProfileImageService.ts
@@ -1,0 +1,32 @@
+/**
+ * Profile image service interface for managing user profile images
+ */
+export interface IProfileImageService {
+  /**
+   * Upload a profile image for a user
+   * @param userId - The user ID
+   * @param file - The image file to upload
+   * @returns Promise that resolves to the image URL
+   */
+  uploadProfileImage(userId: string, file: File): Promise<string>;
+
+  /**
+   * Get the profile image URL for a user
+   * @param userId - The user ID
+   * @returns Promise that resolves to the image URL or null if no image
+   */
+  getProfileImage(userId: string): Promise<string | null>;
+
+  /**
+   * Get the default avatar URL
+   * @returns The default avatar URL or data URL
+   */
+  getDefaultAvatar(): string;
+
+  /**
+   * Validate an image file
+   * @param file - The image file to validate
+   * @returns True if valid, false otherwise
+   */
+  validateImageFile(file: File): { isValid: boolean; error?: string };
+}

--- a/templates/todo-app/src/services/interfaces/IStorageService.ts
+++ b/templates/todo-app/src/services/interfaces/IStorageService.ts
@@ -1,0 +1,6 @@
+export interface IStorageService {
+  get<T>(key: string): T | null;
+  set<T>(key: string, value: T): void;
+  remove(key: string): void;
+  clear(): void;
+}

--- a/templates/todo-app/src/services/interfaces/ITodoService.ts
+++ b/templates/todo-app/src/services/interfaces/ITodoService.ts
@@ -1,0 +1,12 @@
+import { Todo } from '../../../rayfin/data/Todo';
+
+export interface ITodoService {
+  getTodos(): Promise<Todo[]>;
+  getTodoById(id: string): Promise<Todo | null>;
+  createTodo(todo: Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>): Promise<Todo>;
+  updateTodo(
+    id: string,
+    updates: Partial<Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>>
+  ): Promise<Todo>;
+  deleteTodo(id: string): Promise<void>;
+}

--- a/templates/todo-app/src/services/mock/LocalStorageService.ts
+++ b/templates/todo-app/src/services/mock/LocalStorageService.ts
@@ -1,0 +1,36 @@
+import { IStorageService } from '../interfaces/IStorageService';
+
+export class LocalStorageService implements IStorageService {
+  get<T>(key: string): T | null {
+    try {
+      const value = localStorage.getItem(key);
+      return value ? JSON.parse(value) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  set<T>(key: string, value: T): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Silently fail if localStorage is not available
+    }
+  }
+
+  remove(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Silently fail if localStorage is not available
+    }
+  }
+
+  clear(): void {
+    try {
+      localStorage.clear();
+    } catch {
+      // Silently fail if localStorage is not available
+    }
+  }
+}

--- a/templates/todo-app/src/services/mock/MockAuthService.ts
+++ b/templates/todo-app/src/services/mock/MockAuthService.ts
@@ -1,0 +1,150 @@
+import { AuthUser } from '../../models/AuthUser';
+import {
+  IAuthService,
+  MagicLinkCallbackResult,
+  MagicLinkSendResult,
+  SignUpResult,
+} from '../interfaces/IAuthService';
+import { IStorageService } from '../interfaces/IStorageService';
+
+export class MockAuthService implements IAuthService {
+  private readonly CURRENT_USER_KEY = 'todo_app_current_user';
+  private readonly MAGIC_LINK_STATE_KEY = 'todo_app_magic_link_state';
+
+  constructor(private storage: IStorageService) {}
+
+  async signUp(email: string, password: string): Promise<SignUpResult> {
+    // Mock implementation - just log the signup
+    console.log('MockAuthService: Signing up user:', email);
+    // In mock mode, signup always succeeds and email is auto-verified
+    // Note: User is NOT automatically logged in - they need to login
+    return { emailVerified: true };
+  }
+
+  async login(email: string, password: string): Promise<AuthUser> {
+    // Mock users for demo
+    const users = [
+      { Id: '1', Email: 'alice@example.com', Name: 'Alice Johnson' },
+      { Id: '2', Email: 'bob@example.com', Name: 'Bob Smith' },
+      { Id: '3', Email: 'charlie@example.com', Name: 'Charlie Brown' },
+    ];
+
+    const user = users.find((u) => u.Email === email);
+    if (!user || password !== 'password123') {
+      throw new Error('Invalid credentials');
+    }
+
+    const authUser: AuthUser = {
+      ...user,
+    };
+
+    this.storage.set(this.CURRENT_USER_KEY, authUser);
+    return authUser;
+  }
+
+  async logout(): Promise<void> {
+    this.storage.remove(this.CURRENT_USER_KEY);
+  }
+
+  async getCurrentUser(): Promise<AuthUser | null> {
+    return this.storage.get<AuthUser>(this.CURRENT_USER_KEY);
+  }
+
+  async isAuthenticated(): Promise<boolean> {
+    return this.storage.get<AuthUser>(this.CURRENT_USER_KEY) !== null;
+  }
+
+  async verifyEmail(token: string): Promise<void> {
+    // Mock implementation - always succeeds
+    console.log('MockAuthService: Verifying email with token', token);
+    // In mock mode, verification is instant
+  }
+
+  async resendVerificationEmail(
+    email: string
+  ): Promise<{ success: boolean; message: string }> {
+    // Mock implementation - always succeeds
+    console.log('MockAuthService: Resending verification email to', email);
+    return {
+      success: true,
+      message: 'Verification email has been resent successfully.',
+    };
+  }
+
+  async sendMagicLink(
+    email: string,
+    redirectUri: string
+  ): Promise<MagicLinkSendResult> {
+    // Mock implementation - simulate sending magic link
+    console.log(
+      'MockAuthService: Sending magic link to',
+      email,
+      'with redirect',
+      redirectUri
+    );
+
+    // Generate a mock state for the magic link flow
+    const state = `mock_state_${Date.now()}`;
+
+    // Store the state and email for callback handling
+    this.storage.set(this.MAGIC_LINK_STATE_KEY, { state, email, redirectUri });
+
+    return {
+      success: true,
+      state,
+      message: 'Magic link sent! Check your inbox.',
+    };
+  }
+
+  async handleMagicLinkCallback(): Promise<MagicLinkCallbackResult> {
+    // Mock implementation - auto-login the user from stored state
+    const storedState = this.storage.get<{
+      state: string;
+      email: string;
+      redirectUri: string;
+    }>(this.MAGIC_LINK_STATE_KEY);
+
+    if (!storedState) {
+      return {
+        success: false,
+        error: 'No magic link session found',
+      };
+    }
+
+    // Clear the stored state
+    this.storage.remove(this.MAGIC_LINK_STATE_KEY);
+
+    // Create a mock user from the email
+    const user: AuthUser = {
+      Id: `mock_${Date.now()}`,
+      Email: storedState.email,
+      Name: storedState.email.split('@')[0],
+    };
+
+    // Store the user as logged in
+    this.storage.set(this.CURRENT_USER_KEY, user);
+
+    return {
+      success: true,
+      user,
+    };
+  }
+
+  isMagicLinkCallback(): boolean {
+    // Check if URL contains magic link callback parameters
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.has('code') && urlParams.has('state');
+  }
+
+  async initiateFabricLogin(): Promise<void> {
+    throw new Error('Fabric authentication is not available in mock mode.');
+  }
+
+  async ensureSignedInWithFabric(): Promise<AuthUser> {
+    throw new Error('Fabric authentication is not available in mock mode.');
+  }
+
+  async initEmbeddedAuth(): Promise<AuthUser | null> {
+    return null;
+  }
+}

--- a/templates/todo-app/src/services/mock/MockCategoryService.ts
+++ b/templates/todo-app/src/services/mock/MockCategoryService.ts
@@ -1,0 +1,186 @@
+import { Category } from '../../../rayfin/data/Category';
+import { IAuthService } from '../interfaces/IAuthService';
+import { ICategoryService } from '../interfaces/ICategoryService';
+import { IStorageService } from '../interfaces/IStorageService';
+
+export class MockCategoryService implements ICategoryService {
+  private readonly CATEGORIES_KEY = 'todo_app_categories';
+
+  // Predefined color palette for categories
+  private readonly CATEGORY_COLORS = [
+    '#3B82F6', // Blue
+    '#10B981', // Green
+    '#8B5CF6', // Purple
+    '#EF4444', // Red
+    '#F59E0B', // Amber
+    '#06B6D4', // Cyan
+    '#84CC16', // Lime
+    '#EC4899', // Pink
+  ];
+
+  constructor(
+    private storage: IStorageService,
+    private auth: IAuthService
+  ) {
+    // Initialize with demo data if empty
+    if (!this.storage.get(this.CATEGORIES_KEY)) {
+      this.initializeDemoData();
+    }
+  }
+
+  private async initializeDemoData(): Promise<void> {
+    const demoCategories: Category[] = [
+      // Alice's categories
+      {
+        id: '1',
+        name: 'Work',
+        color: '#3B82F6',
+        user_id: '1',
+      },
+      {
+        id: '2',
+        name: 'Personal',
+        color: '#10B981',
+        user_id: '1',
+      },
+      {
+        id: '3',
+        name: 'Shopping',
+        color: '#8B5CF6',
+        user_id: '1',
+      },
+      {
+        id: '4',
+        name: 'Health',
+        color: '#EF4444',
+        user_id: '1',
+      },
+
+      // Bob's categories
+      {
+        id: '5',
+        name: 'Work',
+        color: '#3B82F6',
+        user_id: '2',
+      },
+      {
+        id: '6',
+        name: 'Family',
+        color: '#10B981',
+        user_id: '2',
+      },
+      {
+        id: '7',
+        name: 'Hobbies',
+        color: '#F59E0B',
+        user_id: '2',
+      },
+
+      // Charlie's categories
+      {
+        id: '8',
+        name: 'School',
+        color: '#06B6D4',
+        user_id: '3',
+      },
+      {
+        id: '9',
+        name: 'Sports',
+        color: '#84CC16',
+        user_id: '3',
+      },
+    ];
+    this.storage.set(this.CATEGORIES_KEY, demoCategories);
+  }
+
+  private getNextColor(existingCategories: Category[]): string {
+    const usedColors = existingCategories.map((c) => c.color);
+    const availableColors = this.CATEGORY_COLORS.filter(
+      (color) => !usedColors.includes(color)
+    );
+
+    if (availableColors.length > 0) {
+      return availableColors[0];
+    }
+
+    // If all predefined colors are used, generate a random color
+    return this.generateRandomColor();
+  }
+
+  private generateRandomColor(): string {
+    const hue = Math.floor(Math.random() * 360);
+    return `hsl(${hue}, 65%, 55%)`;
+  }
+
+  async getCategories(): Promise<Category[]> {
+    const currentUser = await this.auth.getCurrentUser();
+    if (!currentUser) {
+      throw new Error('User must be authenticated to fetch categories');
+    }
+
+    const categories = this.storage.get<Category[]>(this.CATEGORIES_KEY) || [];
+    return categories.filter((category) => category.user_id === currentUser.Id);
+  }
+
+  async getCategoryById(id: string): Promise<Category | null> {
+    const categories = this.storage.get<Category[]>(this.CATEGORIES_KEY) || [];
+    return categories.find((category) => category.id === id) || null;
+  }
+
+  async createCategory(category: Omit<Category, 'id'>): Promise<Category> {
+    const currentUser = await this.auth.getCurrentUser();
+    if (!currentUser) {
+      throw new Error('User must be authenticated to create categories');
+    }
+
+    const categories = this.storage.get<Category[]>(this.CATEGORIES_KEY) || [];
+    const userCategories = categories.filter(
+      (c) => c.user_id === currentUser.Id
+    );
+
+    const newCategory: Category = {
+      id: crypto.randomUUID(),
+      name: category.name,
+      color: category.color || this.getNextColor(userCategories),
+      user_id: currentUser.Id,
+    };
+
+    categories.push(newCategory);
+    this.storage.set(this.CATEGORIES_KEY, categories);
+
+    return newCategory;
+  }
+
+  async updateCategory(
+    id: string,
+    updates: Partial<Omit<Category, 'id'>>
+  ): Promise<Category> {
+    const categories = this.storage.get<Category[]>(this.CATEGORIES_KEY) || [];
+    const index = categories.findIndex((category) => category.id === id);
+
+    if (index === -1) {
+      throw new Error('Category not found');
+    }
+
+    const updatedCategory = {
+      ...categories[index],
+      ...updates,
+    };
+
+    categories[index] = updatedCategory;
+    this.storage.set(this.CATEGORIES_KEY, categories);
+
+    return updatedCategory;
+  }
+
+  async deleteCategory(id: string): Promise<void> {
+    const categories = this.storage.get<Category[]>(this.CATEGORIES_KEY) || [];
+    const filteredCategories = categories.filter(
+      (category) => category.id !== id
+    );
+    this.storage.set(this.CATEGORIES_KEY, filteredCategories);
+
+    // Note: Todos with this category will need to be unassigned by the TodoService
+    // This is handled in the useTodos hook when categories are deleted
+  }
+}

--- a/templates/todo-app/src/services/mock/MockProfileImageService.ts
+++ b/templates/todo-app/src/services/mock/MockProfileImageService.ts
@@ -1,0 +1,141 @@
+import { IProfileImageService } from '../interfaces/IProfileImageService';
+import { IStorageService } from '../interfaces/IStorageService';
+
+interface StoredImage {
+  url: string;
+  timestamp: number;
+}
+
+export class MockProfileImageService implements IProfileImageService {
+  private readonly PROFILE_IMAGES_KEY = 'todo_app_profile_images';
+  private readonly MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+  private readonly ALLOWED_TYPES = [
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+  ];
+
+  constructor(private storage: IStorageService) {}
+
+  async uploadProfileImage(userId: string, file: File): Promise<string> {
+    // Validate the file
+    const validation = this.validateImageFile(file);
+    if (!validation.isValid) {
+      throw new Error(validation.error || 'Invalid image file');
+    }
+
+    try {
+      // Convert file to base64 data URL for mock storage
+      const dataUrl = await this.fileToDataUrl(file);
+
+      // Get existing profile images from storage
+      const profileImages =
+        this.storage.get<Record<string, StoredImage[]>>(
+          this.PROFILE_IMAGES_KEY
+        ) || {};
+
+      // Create new image entry with timestamp
+      const newImage: StoredImage = {
+        url: dataUrl,
+        timestamp: Date.now(),
+      };
+
+      // Add to user's image array (keeping all images)
+      if (!profileImages[userId]) {
+        profileImages[userId] = [];
+      }
+      profileImages[userId].push(newImage);
+
+      this.storage.set(this.PROFILE_IMAGES_KEY, profileImages);
+
+      // Verify persistence (LocalStorageService.set swallows errors). If it didn't persist,
+      // treat it as a quota/availability failure so callers can react.
+      const verify =
+        this.storage.get<Record<string, StoredImage[]>>(
+          this.PROFILE_IMAGES_KEY
+        ) || {};
+      const userImages = verify[userId];
+      if (!userImages || !userImages.some((img) => img.url === dataUrl)) {
+        throw new Error(
+          'Could not persist image (storage unavailable or quota exceeded)'
+        );
+      }
+
+      return dataUrl;
+    } catch (error) {
+      throw new Error(
+        'Failed to upload profile image: ' +
+          (error instanceof Error ? error.message : 'Unknown error')
+      );
+    }
+  }
+
+  async getProfileImage(userId: string): Promise<string | null> {
+    const profileImages =
+      this.storage.get<Record<string, StoredImage[]>>(
+        this.PROFILE_IMAGES_KEY
+      ) || {};
+    const userImages = profileImages[userId];
+    if (!userImages || userImages.length === 0) {
+      return null;
+    }
+    // Return the most recent image (highest timestamp)
+    const latestImage = userImages.reduce((latest, current) =>
+      current.timestamp > latest.timestamp ? current : latest
+    );
+    return latestImage.url;
+  }
+
+  getDefaultAvatar(): string {
+    // Return a simple SVG avatar as a data URL
+    const svg = `
+      <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="20" r="20" fill="#e5e7eb"/>
+        <circle cx="20" cy="16" r="6" fill="#9ca3af"/>
+        <ellipse cx="20" cy="32" rx="8" ry="6" fill="#9ca3af"/>
+      </svg>
+    `;
+    return `data:image/svg+xml;base64,${btoa(svg)}`;
+  }
+
+  validateImageFile(file: File): { isValid: boolean; error?: string } {
+    // Check file type
+    if (!this.ALLOWED_TYPES.includes(file.type)) {
+      return {
+        isValid: false,
+        error:
+          'Please select a valid image file (JPEG, JPG, PNG, GIF, or WebP)',
+      };
+    }
+
+    // Check file size
+    if (file.size > this.MAX_FILE_SIZE) {
+      return {
+        isValid: false,
+        error: 'Image file must be smaller than 2MB',
+      };
+    }
+
+    return { isValid: true };
+  }
+
+  /**
+   * Convert a File to a data URL
+   */
+  private fileToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === 'string') {
+          resolve(reader.result);
+        } else {
+          reject(new Error('Failed to read file as data URL'));
+        }
+      };
+      reader.onerror = () => reject(new Error('Failed to read file'));
+      reader.readAsDataURL(file);
+    });
+  }
+}

--- a/templates/todo-app/src/services/mock/MockTodoService.ts
+++ b/templates/todo-app/src/services/mock/MockTodoService.ts
@@ -1,0 +1,187 @@
+import { Todo } from '../../../rayfin/data/Todo';
+import { IAuthService } from '../interfaces/IAuthService';
+import { IStorageService } from '../interfaces/IStorageService';
+import { ITodoService } from '../interfaces/ITodoService';
+
+export class MockTodoService implements ITodoService {
+  private readonly TODOS_KEY = 'todo_app_todos';
+
+  constructor(
+    private storage: IStorageService,
+    private auth: IAuthService
+  ) {
+    // Initialize with demo data if empty
+    if (!this.storage.get(this.TODOS_KEY)) {
+      this.initializeDemoData();
+    }
+  }
+
+  private async initializeDemoData(): Promise<void> {
+    const demoTodos: Todo[] = [
+      {
+        id: '1',
+        Title: 'Complete project proposal',
+        description: 'Finish the Q3 project proposal for the new client',
+        isCompleted: false,
+        priority: 'high',
+        dueDate: new Date('2024-12-31'),
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        category: {
+          id: '1',
+          name: 'Work',
+          color: '#3B82F6',
+          user_id: '1',
+        },
+        user_id: '1',
+        points: 0,
+        percentComplete: 0,
+      },
+      {
+        id: '2',
+        Title: 'Review code changes',
+        isCompleted: true,
+        priority: 'medium',
+        createdAt: new Date('2024-01-02'),
+        updatedAt: new Date('2024-01-02'),
+        category: {
+          id: '1',
+          name: 'Work',
+          color: '#3B82F6',
+          user_id: '1',
+        },
+        user_id: '1',
+        points: 0,
+        percentComplete: 0,
+      },
+      {
+        id: '3',
+        Title: 'Buy groceries',
+        description: 'Milk, bread, eggs, and vegetables for the week',
+        isCompleted: false,
+        priority: 'medium',
+        createdAt: new Date('2024-01-03'),
+        updatedAt: new Date('2024-01-03'),
+        category: {
+          id: '3',
+          name: 'Shopping',
+          color: '#8B5CF6',
+          user_id: '1',
+        },
+        user_id: '1',
+        points: 0,
+        percentComplete: 0,
+      },
+      {
+        id: '4',
+        Title: 'Call dentist for appointment',
+        isCompleted: false,
+        priority: 'low',
+        createdAt: new Date('2024-01-04'),
+        updatedAt: new Date('2024-01-04'),
+        category: {
+          id: '4',
+          name: 'Health',
+          color: '#EF4444',
+          user_id: '1',
+        },
+        user_id: '1',
+        points: 0,
+        percentComplete: 0,
+      },
+      {
+        id: '5',
+        Title: 'Plan weekend trip',
+        description: 'Research destinations and book accommodation',
+        isCompleted: false,
+        priority: 'low',
+        createdAt: new Date('2024-01-05'),
+        updatedAt: new Date('2024-01-05'),
+        category: {
+          id: '2',
+          name: 'Personal',
+          color: '#10B981',
+          user_id: '1',
+        },
+        user_id: '1',
+        points: 0,
+        percentComplete: 0,
+      },
+      {
+        id: '6',
+        Title: 'Read technical documentation',
+        isCompleted: false,
+        priority: 'medium',
+        createdAt: new Date('2024-01-06'),
+        updatedAt: new Date('2024-01-06'),
+        // No category - demonstrates uncategorized todos
+        user_id: '1',
+        points: 0,
+        percentComplete: 0,
+      },
+    ];
+    this.storage.set(this.TODOS_KEY, demoTodos);
+  }
+
+  async getTodos(): Promise<Todo[]> {
+    const currentUser = await this.auth.getCurrentUser();
+    if (!currentUser) {
+      throw new Error('User must be authenticated to fetch todos');
+    }
+
+    const todos = this.storage.get<Todo[]>(this.TODOS_KEY) || [];
+    return todos.filter((todo) => todo.user_id === currentUser.Id);
+  }
+
+  async getTodoById(id: string): Promise<Todo | null> {
+    const todos = this.storage.get<Todo[]>(this.TODOS_KEY) || [];
+    return todos.find((todo) => todo.id === id) || null;
+  }
+
+  async createTodo(
+    todo: Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<Todo> {
+    const todos = this.storage.get<Todo[]>(this.TODOS_KEY) || [];
+    const currentUser = await this.auth.getCurrentUser();
+
+    const newTodo: Todo = {
+      ...todo,
+      id: crypto.randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      // Ensure the user_id is set correctly
+      user_id: currentUser?.Id || todo.user_id,
+    };
+    todos.push(newTodo);
+    this.storage.set(this.TODOS_KEY, todos);
+    return newTodo;
+  }
+
+  async updateTodo(
+    id: string,
+    updates: Partial<Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>>
+  ): Promise<Todo> {
+    const todos = this.storage.get<Todo[]>(this.TODOS_KEY) || [];
+    const index = todos.findIndex((todo) => todo.id === id);
+
+    if (index === -1) {
+      throw new Error('Todo not found');
+    }
+
+    const updatedTodo = {
+      ...todos[index],
+      ...updates,
+      updatedAt: new Date(),
+    };
+
+    todos[index] = updatedTodo;
+    this.storage.set(this.TODOS_KEY, todos);
+    return updatedTodo;
+  }
+
+  async deleteTodo(id: string): Promise<void> {
+    const todos = this.storage.get<Todo[]>(this.TODOS_KEY) || [];
+    const filteredTodos = todos.filter((todo) => todo.id !== id);
+    this.storage.set(this.TODOS_KEY, filteredTodos);
+  }
+}

--- a/templates/todo-app/src/services/rayfin/README.md
+++ b/templates/todo-app/src/services/rayfin/README.md
@@ -1,0 +1,51 @@
+# Rayfin Service Integration
+
+This directory contains the implementations of the application services using the Rayfin client.
+
+## Services
+
+- `RayfinAuthService`: Implements the `IAuthService` interface using the Rayfin authentication API
+- `RayfinInitializer`: Provides utility functions to initialize the Rayfin client
+
+## Usage
+
+To use these services, you need to initialize the ServiceContainer with the "rayfin" mode:
+
+```typescript
+// In main.tsx or app initialization
+import { ServiceContainer } from './services/ServiceContainer';
+
+// Initialize with Rayfin services
+ServiceContainer.create('rayfin');
+```
+
+## Requirements
+
+- A running backend service that implements the Rayfin API
+- The `@microsoft/rayfin-client` package installed
+
+## Testing Without Backend
+
+When developing without a backend service:
+
+1. Use mock mode instead:
+
+   ```typescript
+   ServiceContainer.create('mock');
+   ```
+
+2. This will use the mock services that store data in localStorage.
+
+## Switching Between Mock and Rayfin
+
+The application is designed to easily switch between mock and real implementations:
+
+```typescript
+// For development without backend
+ServiceContainer.create('mock');
+
+// For production with backend
+ServiceContainer.create('rayfin');
+```
+
+This allows for easy testing and development without requiring a running backend service.

--- a/templates/todo-app/src/services/rayfin/RayfinAuthService.ts
+++ b/templates/todo-app/src/services/rayfin/RayfinAuthService.ts
@@ -1,0 +1,326 @@
+import { AuthUser } from '../../models/AuthUser';
+import {
+  IAuthService,
+  MagicLinkCallbackResult,
+  MagicLinkSendResult,
+  SignUpResult,
+} from '../interfaces/IAuthService';
+
+import { getRayfinClient } from './RayfinClientService';
+
+/**
+ * Implementation of IAuthService using Rayfin client
+ *
+ * NOTE: This service requires a running backend API that implements
+ * the authentication endpoints. When no backend is available,
+ * use the mock implementation through ServiceContainer.create('mock')
+ */
+export class RayfinAuthService implements IAuthService {
+  async signUp(email: string, password: string): Promise<SignUpResult> {
+    try {
+      const client = getRayfinClient();
+      const response = await client.auth.signUp({ email, password });
+      return { emailVerified: response.emailVerified };
+    } catch (error: any) {
+      console.error('RayfinAuthService signUp error:', error);
+
+      // Check for duplicate email (HTTP 409)
+      if (error.status === 409) {
+        throw new Error('An account with this email already exists.');
+      }
+
+      // Generic fallback error
+      throw new Error('Signup failed. Please try again.');
+    }
+  }
+
+  async login(email: string, password: string): Promise<AuthUser> {
+    try {
+      const client = getRayfinClient();
+      await client.auth.signIn({ email, password });
+
+      // Get user info from the session (opaque, doesn't expose tokens)
+      const session = client.auth.getSession();
+
+      if (!session.isAuthenticated || !session.user) {
+        throw new Error('Failed to establish session');
+      }
+
+      // Map from session to our User model
+      return {
+        Id: session.user.id,
+        Email: session.user.email,
+        Name: session.user.email.split('@')[0], // Simple fallback if name not provided
+      };
+    } catch (error: any) {
+      console.error('RayfinAuthService login error:', error);
+
+      // Check for email not verified error (HTTP 403 from backend)
+      if (error.status === 403 || error.code === 'EMAIL_NOT_VERIFIED') {
+        throw new Error(
+          'Please verify your email before signing in. Check your inbox for the verification link.'
+        );
+      }
+
+      // Check for invalid credentials (HTTP 401)
+      if (error.status === 401) {
+        throw new Error('Invalid email or password.');
+      }
+
+      // Generic fallback error
+      throw new Error('Login failed. Please check your credentials.');
+    }
+  }
+
+  async logout(): Promise<void> {
+    try {
+      const client = getRayfinClient();
+      await client.auth.signOut();
+    } catch (error) {
+      console.error('RayfinAuthService logout error:', error);
+      throw new Error('Logout failed.');
+    }
+  }
+
+  async getCurrentUser(): Promise<AuthUser | null> {
+    const client = getRayfinClient();
+    const session = client.auth.getSession();
+    if (!session || !session.user) {
+      return null;
+    }
+
+    return {
+      Id: session.user.id,
+      Email: session.user.email,
+      Name: session.user.email.split('@')[0], // Simple fallback
+    };
+  }
+
+  async isAuthenticated(): Promise<boolean> {
+    const client = getRayfinClient();
+    const session = client.auth.getSession();
+    return !!session;
+  }
+
+  async verifyEmail(token: string): Promise<void> {
+    try {
+      const client = getRayfinClient();
+      await client.auth.verifyEmail(token);
+    } catch (error: any) {
+      console.error('RayfinAuthService verifyEmail error:', error);
+
+      // Check for expired token
+      if (error.status === 400 || error.message?.includes('expired')) {
+        throw new Error(
+          'Verification link has expired. Please request a new one.'
+        );
+      }
+
+      // Check for invalid token
+      if (error.status === 404 || error.message?.includes('invalid')) {
+        throw new Error('Invalid verification link.');
+      }
+
+      throw new Error('Email verification failed. Please try again.');
+    }
+  }
+
+  async resendVerificationEmail(
+    email: string
+  ): Promise<{ success: boolean; message: string }> {
+    try {
+      const client = getRayfinClient();
+      const result = await client.auth.resendVerificationEmail(email);
+      return result;
+    } catch (error: any) {
+      console.error('RayfinAuthService resendVerificationEmail error:', error);
+      throw new Error('Failed to resend verification email. Please try again.');
+    }
+  }
+
+  async sendMagicLink(
+    email: string,
+    redirectUri: string
+  ): Promise<MagicLinkSendResult> {
+    try {
+      const client = getRayfinClient();
+      const result = await client.auth.sendMagicLink({
+        email,
+        redirectUri,
+      });
+      return {
+        success: result.success,
+        state: result.state,
+        message: result.message,
+      };
+    } catch (error: any) {
+      console.error('RayfinAuthService sendMagicLink error:', error);
+
+      // Check for rate limiting
+      if (error.status === 429) {
+        throw new Error(
+          'Too many requests. Please wait a moment and try again.'
+        );
+      }
+
+      throw new Error('Failed to send magic link. Please try again.');
+    }
+  }
+
+  async handleMagicLinkCallback(): Promise<MagicLinkCallbackResult> {
+    try {
+      const client = getRayfinClient();
+      const result = await client.auth.handleMagicLinkCallback();
+
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.error ?? 'Magic link authentication failed',
+        };
+      }
+
+      // Get user info from the session
+      const session = client.auth.getSession();
+
+      if (!session.isAuthenticated || !session.user) {
+        return {
+          success: false,
+          error: 'Failed to establish session',
+        };
+      }
+
+      const user: AuthUser = {
+        Id: session.user.id,
+        Email: session.user.email,
+        Name: session.user.email.split('@')[0],
+      };
+
+      return {
+        success: true,
+        user,
+      };
+    } catch (error: any) {
+      console.error('RayfinAuthService handleMagicLinkCallback error:', error);
+
+      // Check for expired token
+      if (error.status === 400 || error.message?.includes('expired')) {
+        return {
+          success: false,
+          error: 'Magic link has expired. Please request a new one.',
+        };
+      }
+
+      // Check for invalid token
+      if (error.status === 404 || error.message?.includes('invalid')) {
+        return {
+          success: false,
+          error: 'Invalid magic link.',
+        };
+      }
+
+      return {
+        success: false,
+        error: 'Magic link authentication failed. Please try again.',
+      };
+    }
+  }
+
+  isMagicLinkCallback(): boolean {
+    const client = getRayfinClient();
+    return client.auth.isMagicLinkCallback();
+  }
+
+  async initiateFabricLogin(): Promise<void> {
+    const { initiateFabricLogin: sdkInitiateFabricLogin } =
+      await import('@microsoft/rayfin-auth-provider-fabric');
+    const { getFabricConfig } = await import('../../utils/environment');
+
+    const client = getRayfinClient();
+    const fabricConfig = getFabricConfig();
+
+    if (
+      !fabricConfig.workspaceId ||
+      !fabricConfig.projectId ||
+      !fabricConfig.fabricPortalUrl
+    ) {
+      throw new Error('Fabric authentication is not configured.');
+    }
+
+    await sdkInitiateFabricLogin(client.auth, {
+      workspaceId: fabricConfig.workspaceId,
+      projectId: fabricConfig.projectId,
+      fabricPortalUrl: fabricConfig.fabricPortalUrl,
+      returnOrigin: window.location.origin,
+    });
+  }
+
+  async ensureSignedInWithFabric(): Promise<AuthUser> {
+    const { ensureSignedInWithFabric: sdkEnsureSignedIn } =
+      await import('@microsoft/rayfin-auth-provider-fabric');
+    const { getFabricConfig } = await import('../../utils/environment');
+
+    const client = getRayfinClient();
+    const fabricConfig = getFabricConfig();
+
+    if (
+      !fabricConfig.workspaceId ||
+      !fabricConfig.projectId ||
+      !fabricConfig.fabricPortalUrl
+    ) {
+      throw new Error('Fabric authentication is not configured.');
+    }
+
+    const session = await sdkEnsureSignedIn(client.auth, {
+      workspaceId: fabricConfig.workspaceId,
+      projectId: fabricConfig.projectId,
+      fabricPortalUrl: fabricConfig.fabricPortalUrl,
+      returnOrigin: window.location.origin,
+    });
+
+    if (!session.isAuthenticated || !session.user) {
+      throw new Error(
+        'Fabric authentication completed but no session was established.'
+      );
+    }
+
+    return {
+      Id: session.user.id,
+      Email: session.user.email,
+      Name: session.user.email.split('@')[0],
+    };
+  }
+
+  async initEmbeddedAuth(): Promise<AuthUser | null> {
+    const { initEmbeddedAuth: sdkInitEmbedded } =
+      await import('@microsoft/rayfin-auth-provider-fabric');
+    const { getFabricConfig } = await import('../../utils/environment');
+
+    const client = getRayfinClient();
+    const fabricConfig = getFabricConfig();
+
+    if (
+      !fabricConfig.workspaceId ||
+      !fabricConfig.projectId ||
+      !fabricConfig.fabricPortalUrl
+    ) {
+      return null;
+    }
+
+    const session = await sdkInitEmbedded(client.auth, {
+      workspaceId: fabricConfig.workspaceId,
+      projectId: fabricConfig.projectId,
+      fabricPortalUrl: fabricConfig.fabricPortalUrl,
+      returnOrigin: window.location.origin,
+    });
+
+    if (!session?.isAuthenticated || !session.user) {
+      return null;
+    }
+
+    return {
+      Id: session.user.id,
+      Email: session.user.email,
+      Name: session.user.email.split('@')[0],
+    };
+  }
+}

--- a/templates/todo-app/src/services/rayfin/RayfinCategoryService.ts
+++ b/templates/todo-app/src/services/rayfin/RayfinCategoryService.ts
@@ -1,0 +1,119 @@
+import type { RayfinClient } from '@microsoft/rayfin-client';
+
+import { Category } from '../../../rayfin/data/Category';
+import type { TodoAppSchema } from '../../../rayfin/data/schema';
+import { ICategoryService } from '../interfaces/ICategoryService';
+
+import { getRayfinClient } from './RayfinClientService';
+
+/**
+ * Implementation of ICategoryService using \@microsoft/rayfin-data GraphQL fluent interface
+ *
+ * This service uses the rayfinClient.data.gql property to access the GraphQL API,
+ * providing type-safe query building and execution with fluent syntax for category operations.
+ */
+export class RayfinCategoryService implements ICategoryService {
+  private rayfinClient: RayfinClient<TodoAppSchema>;
+
+  constructor() {
+    // Get the RayfinClient instance once during initialization
+    this.rayfinClient = getRayfinClient();
+  }
+
+  async getCategories(): Promise<Category[]> {
+    try {
+      // Use the GraphQL fluent interface for category queries
+      // User filtering is handled automatically by DAB through JWT claims and RLS
+      const categories = await this.rayfinClient.data.Category.select([
+        'id',
+        'name',
+        'color',
+      ])
+        .orderBy({ name: 'asc' })
+        .execute();
+
+      return categories;
+    } catch (error) {
+      console.error('RayfinCategoryService.getCategories error:', error);
+      throw new Error('Failed to fetch categories');
+    }
+  }
+
+  async getCategoryById(id: string): Promise<Category | null> {
+    try {
+      // Use the GraphQL fluent interface for single category query
+      const categories = await this.rayfinClient.data.Category.select([
+        'id',
+        'name',
+        'color',
+      ])
+        .where({ id: { eq: id } })
+        .first(1)
+        .execute();
+
+      return categories[0] || null;
+    } catch (error) {
+      console.error('RayfinCategoryService.getCategoryById error:', error);
+      throw new Error('Failed to fetch category');
+    }
+  }
+
+  async createCategory(category: Omit<Category, 'id'>): Promise<Category> {
+    try {
+      // Verify user is authenticated before creating category
+      const session = this.rayfinClient.auth.getSession();
+      if (!session?.isAuthenticated || !session.user?.id) {
+        throw new Error('User must be authenticated to create categories');
+      }
+
+      const categoryData = {
+        name: category.name,
+        color: category.color,
+        user_id: session.user.id,
+      };
+
+      // Use GraphQL mutation for creation
+      const newCategory =
+        await this.rayfinClient.data.Category.create(categoryData);
+
+      return newCategory;
+    } catch (error) {
+      console.error('RayfinCategoryService.createCategory error:', error);
+      throw new Error('Failed to create category');
+    }
+  }
+
+  async updateCategory(
+    id: string,
+    updates: Partial<Omit<Category, 'id' | 'todos'>>
+  ): Promise<Category> {
+    try {
+      // Use GraphQL mutation for update - requires WhereUniqueInput format
+      await this.rayfinClient.data.Category.update(
+        { id }, // WhereUniqueInput format
+        updates
+      );
+
+      // Fetch the updated category to return
+      const updatedCategory = await this.getCategoryById(id);
+      if (!updatedCategory) {
+        throw new Error(`Category with id ${id} not found after update`);
+      }
+
+      return updatedCategory;
+    } catch (error) {
+      console.error('RayfinCategoryService.updateCategory error:', error);
+      throw new Error('Failed to update category');
+    }
+  }
+
+  async deleteCategory(id: string): Promise<void> {
+    try {
+      // Use GraphQL mutation for deletion - requires WhereUniqueInput format
+      await this.rayfinClient.data.Category.delete({ id });
+    } catch (error) {
+      console.error('RayfinCategoryService.deleteCategory error:', error);
+      throw new Error('Failed to delete category');
+    }
+  }
+}

--- a/templates/todo-app/src/services/rayfin/RayfinClientService.ts
+++ b/templates/todo-app/src/services/rayfin/RayfinClientService.ts
@@ -1,0 +1,146 @@
+import { RayfinClient } from '@microsoft/rayfin-client';
+import { ExtendableRayfinClient } from '@microsoft/rayfin-client/experimental';
+import { createStorageClient, StorageClient } from '@microsoft/rayfin-storage';
+
+import type { TodoAppSchema } from '../../../rayfin/data/schema';
+import type { TodoAppStorageSchema } from '../../../rayfin/storage/schema';
+
+/**
+ * A singleton service that manages the RayfinClient instance
+ */
+export class RayfinClientService {
+  private static instance: RayfinClientService | null = null;
+  private _client:
+    | (RayfinClient<TodoAppSchema> & {
+        storage: StorageClient<TodoAppStorageSchema>;
+      })
+    | null = null;
+
+  private constructor() {}
+
+  /**
+   * Get the singleton instance of RayfinClientService
+   */
+  public static getInstance(): RayfinClientService {
+    if (!RayfinClientService.instance) {
+      RayfinClientService.instance = new RayfinClientService();
+    }
+    return RayfinClientService.instance;
+  }
+
+  /**
+   * Initialize the RayfinClient with the provided base URL and publishable key
+   *
+   * @param baseUrl - The base URL of the Rayfin API
+   * @param publishableKey - The publishable key for service-level authentication
+   * @param projectId - Optional Rayfin project identifier (set by rayfin up)
+   * @returns The initialized RayfinClient instance
+   */
+  public initialize(
+    baseUrl: string,
+    publishableKey: string
+  ): RayfinClient<TodoAppSchema> & {
+    storage: StorageClient<TodoAppStorageSchema>;
+  } {
+    if (!this._client) {
+      console.log(`🔧 Initializing Rayfin client with baseUrl: ${baseUrl}`);
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Origin: window.location.origin, // Set Origin header for email verification links
+      };
+
+      this._client = ExtendableRayfinClient.create({
+        baseUrl: baseUrl,
+        publishableKey: publishableKey,
+        useProxy: false, // ✨ Fixed: Use direct API calls instead of proxy
+        headers,
+        schema: {} as unknown as TodoAppSchema,
+        services: {
+          storage: createStorageClient<TodoAppStorageSchema>,
+        },
+      });
+
+      // Save the client to the window object for easy access
+      (window as any).rayfinServiceContainer = {
+        client: this._client,
+      };
+
+      console.log(
+        `✅ Rayfin client configured for direct API calls to ${baseUrl}`
+      );
+
+      // Test the connection to the backend
+      this.testConnection();
+    }
+
+    return this._client;
+  }
+
+  /**
+   * Get the RayfinClient instance
+   * @throws Error if the client is not initialized
+   */
+  public getClient(): RayfinClient<TodoAppSchema> & {
+    storage: StorageClient<TodoAppStorageSchema>;
+  } {
+    if (!this._client) {
+      throw new Error('RayfinClient not initialized. Call initialize() first.');
+    }
+    return this._client;
+  }
+
+  /**
+   * Check if the client is initialized
+   */
+  public isInitialized(): boolean {
+    return this._client !== null;
+  }
+
+  /**
+   * Reset the client instance (useful for testing or when switching modes)
+   */
+  public reset(): void {
+    this._client = null;
+    if ((window as any).rayfinServiceContainer) {
+      (window as any).rayfinServiceContainer.client = null;
+    }
+  }
+
+  /**
+   * Test the connection to the backend
+   */
+  private testConnection(): void {
+    if (!this._client) return;
+
+    // Run an async IIFE; ignoring the returned promise is intentional here
+    void (async () => {
+      try {
+        const session = this._client!.auth.getSession();
+        if (session.isAuthenticated) {
+          console.log('✅ Backend connection test completed successfully');
+        } else {
+          console.warn('⚠️ Backend connection test: no active session');
+        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.warn('⚠️ Backend connection test failed:', errorMessage);
+        console.warn(
+          'The app will continue to use the Rayfin client, but authentication operations may fail.'
+        );
+        console.warn('💡 To use mock mode instead, run: npm run dev:mock');
+      }
+    })();
+  }
+}
+
+/**
+ * Helper function to get the RayfinClient instance
+ * @throws Error if the client is not initialized
+ */
+export function getRayfinClient(): RayfinClient<TodoAppSchema> & {
+  storage: StorageClient<TodoAppStorageSchema>;
+} {
+  return RayfinClientService.getInstance().getClient();
+}

--- a/templates/todo-app/src/services/rayfin/RayfinProfileImageService.ts
+++ b/templates/todo-app/src/services/rayfin/RayfinProfileImageService.ts
@@ -1,0 +1,208 @@
+import type { RayfinClient } from '@microsoft/rayfin-client';
+import { StorageClient } from '@microsoft/rayfin-storage';
+
+import type { TodoAppSchema } from '../../../rayfin/data/schema';
+import type { TodoAppStorageSchema } from '../../../rayfin/storage/schema';
+import { IProfileImageService } from '../interfaces/IProfileImageService';
+
+import { getRayfinClient } from './RayfinClientService';
+
+/**
+ * Rayfin implementation of profile image service using Rayfin storage
+ */
+export class RayfinProfileImageService implements IProfileImageService {
+  private rayfinClient: RayfinClient<TodoAppSchema> & {
+    storage: StorageClient<TodoAppStorageSchema>;
+  };
+
+  constructor() {
+    this.rayfinClient = getRayfinClient();
+  }
+
+  /**
+   * Compute the storage prefix for a user's profile images
+   */
+  private getStoragePrefix(userId: string): string {
+    return `users/${userId}`;
+  }
+
+  /**
+   * Common storage options with prefix
+   */
+  private getStorageOptions(userId: string): { prefix: string } {
+    return { prefix: this.getStoragePrefix(userId) };
+  }
+
+  async uploadProfileImage(userId: string, file: File): Promise<string> {
+    // Validate the file
+    const validation = this.validateImageFile(file);
+    if (!validation.isValid) {
+      throw new Error(validation.error || 'Invalid image file');
+    }
+
+    try {
+      // Use the original filename provided by the user
+      const filename = file.name;
+
+      // Upload to Rayfin storage - using the kebab-case folder name from config
+      const result = await this.rayfinClient.storage.ProfileImage.upload(
+        filename,
+        file,
+        {
+          prefix: this.getStoragePrefix(userId),
+          contentType: file.type,
+        }
+      );
+
+      console.log('Profile image uploaded successfully:', result.correlationId);
+      return filename;
+    } catch (error) {
+      console.error('Failed to upload profile image:', error);
+      throw new Error(
+        'Failed to upload profile image: ' +
+          (error instanceof Error ? error.message : 'Unknown error')
+      );
+    }
+  }
+
+  async getProfileImage(userId: string): Promise<string | null> {
+    try {
+      // List most recent file for this user's profile images
+      const list = await this.rayfinClient.storage.ProfileImage.list({
+        prefix: this.getStoragePrefix(userId),
+        limit: 1,
+      });
+
+      // TODO: list of ProfileImage which has no string fields, but actually the client adds
+      // StorageObjectRef. We should make it strongly typed, but only way I know now is to
+      // make ProfileImage extend StorageObjectRef. Needs discussion.
+      const latest = list.items[0] as unknown as { name: string } | undefined;
+      if (!latest) return null;
+
+      // Download the latest image by name using the same prefix
+      const download = await this.rayfinClient.storage.ProfileImage.download(
+        latest.name,
+        this.getStorageOptions(userId)
+      );
+
+      // Infer MIME type from filename for the data URL
+      const mimeType = this.getMimeTypeFromFilename(latest.name);
+      const dataUrl = await this.streamToDataUrl(download.stream, mimeType);
+      return dataUrl;
+    } catch (error) {
+      console.error('Failed to get profile image:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Convert a ReadableStream to a data URL
+   */
+  private async streamToDataUrl(
+    stream: ReadableStream<Uint8Array>,
+    mimeType: string
+  ): Promise<string> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+
+      // Combine all chunks into a single Uint8Array
+      const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+      const combined = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.length;
+      }
+
+      // Convert to blob then to data URL
+      const blob = new Blob([combined], { type: mimeType });
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          if (typeof reader.result === 'string') {
+            resolve(reader.result);
+          } else {
+            reject(new Error('Failed to convert blob to data URL'));
+          }
+        };
+        reader.onerror = () => reject(new Error('Failed to read blob'));
+        reader.readAsDataURL(blob);
+      });
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Get file extension from a File object
+   */
+  // NOTE: We no longer require extension extraction when uploading
+
+  /**
+   * Infer MIME type from a filename's extension
+   */
+  private getMimeTypeFromFilename(name: string): string {
+    const ext = name.toLowerCase().split('.').pop() || '';
+    switch (ext) {
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'gif':
+        return 'image/gif';
+      case 'webp':
+        return 'image/webp';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+
+  getDefaultAvatar(): string {
+    // Return a simple SVG avatar as a data URL
+    const svg = `
+      <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="20" r="20" fill="#e5e7eb"/>
+        <circle cx="20" cy="16" r="6" fill="#9ca3af"/>
+        <ellipse cx="20" cy="32" rx="8" ry="6" fill="#9ca3af"/>
+      </svg>
+    `;
+    return `data:image/svg+xml;base64,${btoa(svg)}`;
+  }
+
+  validateImageFile(file: File): { isValid: boolean; error?: string } {
+    const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+    const ALLOWED_TYPES = [
+      'image/jpeg',
+      'image/jpg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ];
+
+    // Check file type
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return {
+        isValid: false,
+        error: 'Please select a valid image file (JPEG, PNG, GIF, or WebP)',
+      };
+    }
+
+    // Check file size
+    if (file.size > MAX_FILE_SIZE) {
+      return {
+        isValid: false,
+        error: 'Image file must be smaller than 2MB',
+      };
+    }
+
+    return { isValid: true };
+  }
+}

--- a/templates/todo-app/src/services/rayfin/RayfinTodoService.ts
+++ b/templates/todo-app/src/services/rayfin/RayfinTodoService.ts
@@ -1,0 +1,141 @@
+import type { RayfinClient } from '@microsoft/rayfin-client';
+
+import { Todo } from '../../../rayfin/data/Todo';
+import type { TodoAppSchema } from '../../../rayfin/data/schema';
+import { ITodoService } from '../interfaces/ITodoService';
+
+import { getRayfinClient } from './RayfinClientService';
+
+/**
+ * Implementation of ITodoService using \@microsoft/rayfin-data GraphQL fluent interface
+ *
+ * This service uses the rayfinClient.data.gql property to access the GraphQL API,
+ * providing type-safe query building and execution with fluent syntax.
+ */
+export class RayfinTodoService implements ITodoService {
+  private rayfinClient: RayfinClient<TodoAppSchema>;
+
+  constructor() {
+    // Get the RayfinClient instance once during initialization
+    this.rayfinClient = getRayfinClient();
+  }
+
+  async getTodos(): Promise<Todo[]> {
+    try {
+      // Use the GraphQL fluent interface for more sophisticated queries
+      // User filtering is handled automatically by DAB through JWT claims and RLS
+      const todos = await this.rayfinClient.data.Todo.select([
+        'id',
+        'Title',
+        'description',
+        'isCompleted',
+        'priority',
+        'dueDate',
+        'createdAt',
+        'updatedAt',
+        'user_id',
+        'category.id',
+        'category.name',
+        'category.color', // Add category relationship
+        'category.user_id',
+      ])
+        .orderBy({ createdAt: 'desc' })
+        .execute();
+
+      return todos;
+    } catch (error) {
+      console.error('RayfinTodoService.getTodos error:', error);
+      throw new Error('Failed to fetch todos');
+    }
+  }
+
+  async getTodoById(id: string): Promise<Todo | null> {
+    try {
+      // Use the GraphQL fluent interface for more sophisticated queries
+      const todo = await this.rayfinClient.data.Todo.select([
+        'id',
+        'Title',
+        'description',
+        'isCompleted',
+        'priority',
+        'dueDate',
+        'createdAt',
+        'updatedAt',
+        'category.id',
+        'category.name',
+        'category.color', // Add category relationship
+      ])
+        .where({ id: { eq: id } })
+        .first(1)
+        .execute();
+
+      return todo[0] || null;
+    } catch (error) {
+      console.error('RayfinTodoService.getTodoById error:', error);
+      throw new Error('Failed to fetch todo');
+    }
+  }
+
+  async createTodo(
+    todo: Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<Todo> {
+    try {
+      // Prepare the todo data with auto-generated fields
+      const todoData = {
+        ...todo,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // Use GraphQL mutation for creation
+      const newTodo = await this.rayfinClient.data.Todo.create(todoData);
+
+      const newTodoWithCategoryFields = await this.getTodoById(newTodo.id);
+      if (!newTodoWithCategoryFields) {
+        throw new Error(`Todo with id ${newTodo.id} not found after creation`);
+      }
+      return newTodoWithCategoryFields;
+    } catch (error) {
+      console.error('RayfinTodoService.createTodo error:', error);
+      throw new Error('Failed to create todo');
+    }
+  }
+
+  async updateTodo(
+    id: string,
+    updates: Partial<Omit<Todo, 'id' | 'createdAt' | 'updatedAt'>>
+  ): Promise<Todo> {
+    try {
+      // Add updatedAt timestamp to the updates
+      const updateData = {
+        ...updates,
+        updatedAt: new Date(),
+      };
+
+      // Use GraphQL mutation for update - requires WhereUniqueInput format
+      await this.rayfinClient.data.Todo.update(
+        { id }, // WhereUniqueInput format
+        updateData
+      );
+
+      const fullUpdatedTodo = await this.getTodoById(id);
+      if (!fullUpdatedTodo) {
+        throw new Error(`Todo with id ${id} not found after update`);
+      }
+      return fullUpdatedTodo;
+    } catch (error) {
+      console.error('RayfinTodoService.updateTodo error:', error);
+      throw new Error('Failed to update todo');
+    }
+  }
+
+  async deleteTodo(id: string): Promise<void> {
+    try {
+      // Use GraphQL mutation for deletion - requires WhereUniqueInput format
+      await this.rayfinClient.data.Todo.delete({ id });
+    } catch (error) {
+      console.error('RayfinTodoService.deleteTodo error:', error);
+      throw new Error('Failed to delete todo');
+    }
+  }
+}

--- a/templates/todo-app/src/utils/environment.ts
+++ b/templates/todo-app/src/utils/environment.ts
@@ -1,0 +1,61 @@
+/**
+ * Environment utilities for service mode detection.
+ *
+ * Auth method availability is now fetched from the backend via
+ * the AuthSettingsContext, which calls auth.getAuthSettings().
+ * This file only provides service mode detection utilities.
+ */
+
+export type ServiceMode = 'mock' | 'rayfin';
+
+/**
+ * Get the current service mode from VITE_SERVICE_MODE.
+ * Defaults to 'rayfin' if not set.
+ */
+export function getServiceMode(): ServiceMode {
+  const mode = import.meta.env.VITE_SERVICE_MODE;
+  if (mode === 'mock') {
+    return 'mock';
+  }
+  return 'rayfin';
+}
+
+/**
+ * Check if running in mock mode.
+ */
+export function isMockMode(): boolean {
+  return getServiceMode() === 'mock';
+}
+
+/**
+ * Check if running in rayfin mode.
+ */
+export function isRayfinMode(): boolean {
+  return getServiceMode() === 'rayfin';
+}
+
+/**
+ * Get Fabric brokered authentication configuration from environment.
+ */
+export function getFabricConfig(): {
+  workspaceId: string | undefined;
+  projectId: string | undefined;
+  fabricPortalUrl: string | undefined;
+} {
+  return {
+    workspaceId: import.meta.env.VITE_FABRIC_WORKSPACE_ID || undefined,
+    projectId: import.meta.env.VITE_FABRIC_ITEM_ID || undefined,
+    fabricPortalUrl: import.meta.env.VITE_FABRIC_PORTAL_URL || undefined,
+  };
+}
+
+/**
+ * Check if all required Fabric auth environment variables are configured.
+ */
+export function isFabricAuthConfigured(): boolean {
+  return !!(
+    import.meta.env.VITE_FABRIC_WORKSPACE_ID &&
+    import.meta.env.VITE_FABRIC_ITEM_ID &&
+    import.meta.env.VITE_FABRIC_PORTAL_URL
+  );
+}

--- a/templates/todo-app/src/vite-env.d.ts
+++ b/templates/todo-app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/templates/todo-app/tsconfig.json
+++ b/templates/todo-app/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext.Decorators"],
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "noEmit": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./rayfin" }]
+}

--- a/templates/todo-app/vite.config.ts
+++ b/templates/todo-app/vite.config.ts
@@ -1,0 +1,24 @@
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react-swc';
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': resolve(import.meta.dirname, 'src'),
+    },
+  },
+  build: {
+    target: 'es2022',
+  },
+  esbuild: {
+    target: 'es2022',
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'es2022',
+    },
+  },
+});

--- a/templates/todo-app/vitest.config.ts
+++ b/templates/todo-app/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': resolve(import.meta.dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds a new `todo-app` template to the gallery, ported from the todo-app sample in project-rayfin, with Docker local development support.

### What's included

**Full-stack todo app** with:
- Todo CRUD with categories, priorities, due dates
- Dual-mode architecture (mock/rayfin service containers)
- Auth (password + Fabric brokered auth)
- Profile image storage
- Rayfin data entities (Todo, Category) with RLS policies

**Docker local dev support** (preview feature):
- `npm run dev:local` — starts Docker-based Rayfin backend with `docker-local-dev` feature flag
- `scripts/check-docker-ghcr.mjs` — pre-flight check that validates Docker is running and `ghcr.io` auth is configured
- Additional scripts: `dev:local:db`, `dev:local:status`, `dev:local:stop`, `dev:local:purge`
- Uses `cross-env` for cross-platform env var support

### Stack

React 19, Vite 7, TypeScript 5, Tailwind CSS 4, Vitest, ESLint 9 (flat config)

### Template checklist

- [x] Lives in `templates/todo-app/`
- [x] All required files per template guidelines
- [x] Matching identifiers across `package.json`, `manifest.json`, `rayfin/rayfin.yml`
- [x] README with Getting started, Project structure, Scripts sections
- [x] Gallery baseline stack (React 19/Vite 7/TS 5/Tailwind 4/Vitest/ESLint 9)
- [x] `generate-manifest.mjs` run — manifests and README table updated
- [x] `generate-manifest.mjs --check` passes