### PR TITLE
fix(todo-local-experimental): Docker check works on Windows + cross-platform docs

### DIFF
--- a/.agents/skills/template-gallery/SKILL.md
+++ b/.agents/skills/template-gallery/SKILL.md
@@ -96,6 +96,23 @@ If any required file is missing, add it before considering the template complete
 3. Link to the page from navigation or the relevant entry point.
 4. Verify the page works with the template's auth and data model.
 
+## Cross-platform compatibility (Windows + macOS/Linux)
+
+Templates are used on Windows, macOS, and Linux. Check for platform issues when adding or modifying scripts:
+
+- **Prefer `.mjs` over `.sh`** for any script that end users run. Shell scripts are fine for contributor tooling only (e.g., `scripts/new-template.sh`).
+- **No Unix-only assumptions** in runtime scripts: avoid hardcoded Unix socket paths (`/var/run/docker.sock`), symlinks, or POSIX-only APIs without a Windows fallback.
+- **Use `process.platform` guards** when behavior diverges (e.g., Docker daemon detection uses sockets on Unix but named pipes/CLI on Windows).
+- **Use `cross-env`** for environment variables in npm scripts — never rely on `VAR=value cmd` syntax.
+- **Avoid path separators** in JS: use `path.join()`/`path.resolve()` instead of string concatenation with `/`.
+- **`&&` chaining in npm scripts** is safe (works in cmd, PowerShell 7+, and bash).
+
+When reviewing or validating a template, scan scripts for:
+1. Hardcoded Unix paths (`/var/run/`, `/tmp/`, `~/.docker/run/`)
+2. Socket or pipe assumptions without platform checks
+3. Shell-specific syntax in npm scripts (backticks, `$(...)`, `export`)
+4. File permission operations (`chmod`, `chown`) without guards
+
 ## Final checklist
 
 - Template structure matches `docs/template-guidelines.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,17 @@ This repository is the **Awesome Rayfin** template gallery, not a single Rayfin 
 - `scripts/generate-manifest.mjs` regenerates the root `rayfin-template.yml`, per-template manifests, and the README templates table.
 - `node scripts/generate-manifest.mjs --check` verifies generated files are up to date.
 
+## Cross-platform compatibility
+
+Templates must work on both Windows and Unix-like systems (macOS/Linux). When adding or modifying scripts:
+
+- Prefer Node.js (`.mjs`) scripts over shell scripts for any logic end users run. Shell scripts (`.sh`) are acceptable for contributor-only tooling.
+- Avoid Unix-only assumptions: don't rely on Unix sockets, `/var/run/`, symlinks, or Unix file permissions in runtime scripts.
+- Use `process.platform` checks or platform-agnostic APIs when behavior differs across OSes (e.g., Docker uses named pipes on Windows vs. Unix sockets on macOS/Linux).
+- Use `cross-env` for setting environment variables in npm scripts.
+- Use `&&` for chaining npm script commands (supported by cmd, PowerShell 7+, and bash).
+- Test that `node --check <script>` passes for any new or modified `.mjs` files.
+
 ## Validation expectations
 
 - CI is defined in `.github/workflows/validate-templates.yml`.

--- a/templates/todo-local-experimental/scripts/check-docker-ghcr.mjs
+++ b/templates/todo-local-experimental/scripts/check-docker-ghcr.mjs
@@ -35,7 +35,7 @@ function run(cmd, args, opts = {}) {
 }
 
 /** Ping the Docker daemon via the Unix socket without invoking the CLI. */
-function pingDocker() {
+function pingDockerSocket() {
   const socketPaths = [
     '/var/run/docker.sock',
     join(homedir(), '.docker', 'run', 'docker.sock'),
@@ -54,6 +54,19 @@ function pingDocker() {
     req.on('error', () => resolve(false));
     req.on('timeout', () => { req.destroy(); resolve(false); });
   });
+}
+
+/** Fallback: check Docker via CLI (used on Windows where Unix sockets aren't available). */
+function pingDockerCli() {
+  return run('docker', ['info']) !== null;
+}
+
+/** Check if Docker daemon is reachable, with platform-appropriate strategy. */
+function pingDocker() {
+  if (process.platform === 'win32') {
+    return Promise.resolve(pingDockerCli());
+  }
+  return pingDockerSocket().then((ok) => ok || pingDockerCli());
 }
 
 // ── 1. Docker daemon check ──────────────────────────────────────────────────


### PR DESCRIPTION
## Description

The `check-docker-ghcr.mjs` script's Docker daemon detection always failed on Windows because it only checked Unix socket paths (which don't exist on Windows). This adds a platform-aware fallback that uses `docker info` via CLI on Windows and as a secondary check on Unix when no socket file is found.

Also adds cross-platform compatibility guidance to `AGENTS.md` and the template-gallery skill so contributors and agents catch similar issues going forward.

## Type of change

- [ ] New template
- [x] Template update
- [x] Gallery infrastructure (CI, scripts, docs)
- [ ] Other

## Template checklist

If adding or modifying a template, confirm:

- [x] `package.json` includes `template.name`, `template.displayName`, and `template.description`
- [x] `manifest.json` has correct `templateId` and `services` flags
- [x] `rayfin/rayfin.yml` has correct `id` and `name` matching the directory name
- [x] `README.md` includes Getting Started, Project Structure, and Scripts sections
- [ ] Ran `node scripts/generate-manifest.mjs` to update manifests and README table
- [ ] Tested scaffolding: `rayfin init -t . --template-name "<name>"` succeeds
- [ ] Ran `npm run lint`, `npm run build`, and `npm test` in the template directory

## Gallery checklist

- [x] `rayfin-template.yml` is up to date (`node scripts/generate-manifest.mjs --check` passes)
- [x] README templates table reflects current templates

## AI disclosure

This PR was authored with Copilot CLI assistance.