### PR TITLE
chore: update rayfin dependencies to 1.33.0

### DIFF
--- a/templates/slide-deck/package.json
+++ b/templates/slide-deck/package.json
@@ -26,10 +26,10 @@
     "rayfin:db": "cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev db apply"
   },
   "dependencies": {
-    "@microsoft/rayfin-auth-provider-fabric": "1.33.0-beta.0",
-    "@microsoft/rayfin-client": "1.33.0-beta.0",
-    "@microsoft/rayfin-core": "1.33.0-beta.0",
-    "@microsoft/rayfin-data": "1.33.0-beta.0",
+    "@microsoft/rayfin-auth-provider-fabric": "1.33.0",
+    "@microsoft/rayfin-client": "1.33.0",
+    "@microsoft/rayfin-core": "1.33.0",
+    "@microsoft/rayfin-data": "1.33.0",
     "@tailwindcss/vite": "^4.1.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
-    "@microsoft/rayfin-cli": "1.33.0-beta.0",
+    "@microsoft/rayfin-cli": "1.33.0",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",

--- a/templates/todo-local-experimental/package.json
+++ b/templates/todo-local-experimental/package.json
@@ -24,10 +24,10 @@
     "rayfin:db": "cross-env RAYFIN_FEATURE_FLAGS=docker-local-dev rayfin dev db apply"
   },
   "dependencies": {
-    "@microsoft/rayfin-auth-provider-fabric": "^1.33.0-beta.0",
-    "@microsoft/rayfin-client": "^1.33.0-beta.0",
-    "@microsoft/rayfin-core": "^1.33.0-beta.0",
-    "@microsoft/rayfin-data": "^1.33.0-beta.0",
+    "@microsoft/rayfin-auth-provider-fabric": "1.33.0",
+    "@microsoft/rayfin-client": "1.33.0",
+    "@microsoft/rayfin-core": "1.33.0",
+    "@microsoft/rayfin-data": "1.33.0",
     "@tailwindcss/vite": "^4.1.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
-    "@microsoft/rayfin-cli": "^1.33.0-beta.3",
+    "@microsoft/rayfin-cli": "1.33.0",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",


### PR DESCRIPTION
## Description

All rayfin packages were pinned to `1.33.0-beta.x` pre-release versions. This updates them to the stable `1.33.0` release across both templates (`slide-deck` and `todo-local-experimental`). The `todo-local-experimental` template also had `^` range prefixes on its rayfin deps, which are removed for consistency with `slide-deck`'s pinned versioning.

## Type of change

- [ ] New template
- [x] Template update
- [ ] Gallery infrastructure (CI, scripts, docs)
- [ ] Other

## Template checklist

If adding or modifying a template, confirm:

- [x] `package.json` includes `template.name`, `template.displayName`, and `template.description`
- [x] `manifest.json` has correct `templateId` and `services` flags
- [x] `rayfin/rayfin.yml` has correct `id` and `name` matching the directory name
- [x] `README.md` includes Getting Started, Project Structure, and Scripts sections
- [ ] Ran `node scripts/generate-manifest.mjs` to update manifests and README table
- [ ] Tested scaffolding: `rayfin init -t . --template-name "<name>"` succeeds
- [ ] Ran `npm run lint`, `npm run build`, and `npm test` in the template directory

## Gallery checklist

- [ ] `rayfin-template.yml` is up to date (`node scripts/generate-manifest.mjs --check` passes)
- [ ] README templates table reflects current templates

## AI disclosure

This PR was authored with Copilot CLI assistance.