### PR TITLE
fix(ci): install libsecret for keytar builds

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install native Node.js build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libsecret-1-dev
+
       - name: Validate template metadata
         run: |
           errors=0
@@ -97,6 +102,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
+
+      - name: Install native Node.js build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libsecret-1-dev
 
       - name: Detect touched templates
         id: detect-templates


### PR DESCRIPTION
&#x1F916; Prevent false template-validation failures when keytar's prebuilt binary download is unavailable.

Linux runners now install `libsecret-1-dev`, allowing keytar to compile from source in both validation jobs.

This unblocks Dependabot PRs #90, #79, and #73, which failed only on the missing native prerequisite.