### PR TITLE
docs(universal-app): point AGENTS.md at the in-project rayfin skill

### DIFF
--- a/templates/universal-app/AGENTS.md
+++ b/templates/universal-app/AGENTS.md
@@ -6,7 +6,7 @@
 > dashboard, a Power BI analytics dashboard, or any mix. Your job is to grow it
 > **on demand**, pulling in only the capabilities the request actually needs.
 
-**Before you write any code, do two things:**
+**Before you write any code, do three things:**
 
 1. **Route first.** Read the **`capability-router` skill**
    (`.agents/skills/capability-router/SKILL.md`). It maps a plain-English request
@@ -16,6 +16,10 @@
 2. **Stay lean.** Don't enable services, install modules, or copy in kit code the
    request doesn't need. The whole point of this template is that it starts small
    and only grows where the user is going.
+3. **Never answer Rayfin APIs from memory.** The router decides *what capabilities
+   to add*; the version-locked skill at `.agents/skills/rayfin/SKILL.md` stays
+   authoritative for *how Rayfin's APIs are actually called*. See
+   [Rayfin docs](#rayfin-docs).
 
 ---
 
@@ -89,6 +93,12 @@ When you finish a capability, build and deploy (`npm run rayfin:up`) to see it o
 Fabric.
 
 ## Rayfin docs
+
+Start with the in-project skill at `.agents/skills/rayfin/SKILL.md`. It ships with
+the packages installed here, so it is version-matched to this project, and it owns
+every Rayfin specific: schema and decorators, the typed data API and client queries,
+auth, storage, and deployment. Prefer it over remembered APIs, which are routinely
+wrong across versions.
 
 Rayfin docs are version-locked to the packages installed in this project.
 Prefer the `rayfin` MCP server in `.mcp.json` and its tools `search_docs`,


### PR DESCRIPTION
## What

Adds the standard Rayfin handoff to the Universal App template's root `AGENTS.md`, and states the boundary between the capability router and the in-project Rayfin skill.

## Why

Raised by @seanwat-msft reviewing microsoft/rayfin#74, which makes this template the default scaffold for the public Copilot plugin's getting-started skill.

The template-owned `AGENTS.md` routed future sessions to the capability packs but never pointed them at `.agents/skills/rayfin/SKILL.md`. The `rayfin` MCP and `rayfin docs` were already covered in the "Rayfin docs" section, so the real gaps were the in-project skill and the division of responsibility.

That matters because the skill is not shipped in the template. The CLI syncs it in during the "synchronizing with latest rayfin scaffolding" step, so it exists in every generated app but was invisible to any agent reading only this file. An agent routed purely to capability packs has nothing version-locked telling it how the Rayfin APIs are actually called, which is the exact situation that produces confidently wrong, remembered API usage.

## Changes

Two edits, one file:

- A third item in the opening checklist: never answer Rayfin APIs from memory. The router decides *what capabilities to add*, the version-locked skill stays authoritative for *how the APIs are called*.
- A lead paragraph in "Rayfin docs" pointing at `.agents/skills/rayfin/SKILL.md` first, noting it ships with the packages installed in the project and therefore matches the version in use.

## Verification

Scaffolded the template through the CLI and confirmed the generated app contains both `AGENTS.md` and `.agents/skills/rayfin/SKILL.md`, so the new reference resolves in the place it is read.

Also ran the seed contract suite in `templates/universal-app`, 10 passed, unrelated to this change but green alongside it.
