### PR TITLE
chore: expand Dependabot coverage across templates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,52 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/templates/field-engineer"
+    directories:
+      - "/scripts"
+      - "/templates/*"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "field-engineer"
     groups:
       rayfin:
         patterns:
           - "@microsoft/rayfin-*"
-
-  - package-ecosystem: "npm"
-    directory: "/templates/events-app"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "events-app"
-    groups:
-      rayfin:
+      runtime-security:
+        applies-to: security-updates
         patterns:
-          - "@microsoft/rayfin-*"
+          - "protobufjs"
+          - "react-router"
+          - "form-data"
+          - "ws"
+          - "socket.io-parser"
+          - "hono"
+      parser-utility-security:
+        applies-to: security-updates
+        patterns:
+          - "js-yaml"
+          - "brace-expansion"
+          - "nanoid"
+          - "tmp"
+          - "image-size"
+      build-security:
+        applies-to: security-updates
+        patterns:
+          - "postcss"
+          - "tar"
+          - "esbuild"
+          - "uuid"
+      test-browser-security:
+        applies-to: security-updates
+        patterns:
+          - "vitest"
+          - "@vitest/mocker"
+          - "browserslist"
+          - "baseline-browser-mapping"
+      remaining-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Expand npm Dependabot coverage from two stale template paths to every maintained template and the repository scripts.

Closes #143.

## Value add

The repository currently has repeated alerts across 15 npm manifests, while the configured template paths no longer exist. Multi-directory monitoring and security-focused groups make future updates complete and reviewable.

## Usage impact

Dependabot will scan `/scripts` and every immediate directory under `/templates`. Security update PRs will be grouped by runtime, parser and utility, build, test and browser, or residual dependencies.

## What changed

- Replaced the obsolete `field-engineer` and `events-app` entries with `/scripts` and `/templates/*` coverage.
- Preserved grouped Rayfin SDK version updates.
- Added ordered security groups aligned with #144, #145, #146, #147, and #148.
- Preserved the existing GitHub Actions update schedule and cooldown.

## Known deferred

This PR changes Dependabot configuration only. The existing alert backlog will be remediated separately through #144, #145, #146, #147, and #148.

Verified: parsed `.github/dependabot.yml`, confirmed coverage of all 15 npm manifests, and ran `node scripts/generate-manifest.mjs --check`.
